### PR TITLE
New shapes, better tests, packaging tweaks and more!

### DIFF
--- a/arlunio/__init__.py
+++ b/arlunio/__init__.py
@@ -1,11 +1,11 @@
-from ._shapes import Canvas, Shape, shape  # noqa: F401
+from ._shapes import Canvas, Shape, ShapeCollection, shape  # noqa: F401
 from ._version import __version__  # noqa: F401
 from .color import RGB8  # noqa: F401
 from .image import Image, Resolutions  # noqa: F401
 from .loaders import load_parameters, load_shapes
 
 Parameters = load_parameters()  # noqa: F401
-Shapes = load_shapes()  # noqa: F401
+Shapes = ShapeCollection(name="lib", collections=load_shapes())  # noqa: F401
 
 # Define some aliases
 S = Shapes  # noqa: F401

--- a/arlunio/__init__.py
+++ b/arlunio/__init__.py
@@ -1,3 +1,4 @@
+from ._expressions import all, any, invert  # noqa: F401
 from ._shapes import Canvas, Shape, ShapeCollection, shape  # noqa: F401
 from ._version import __version__  # noqa: F401
 from .color import RGB8  # noqa: F401

--- a/arlunio/__init__.py
+++ b/arlunio/__init__.py
@@ -1,12 +1,12 @@
 from ._expressions import all, any, invert  # noqa: F401
-from ._shapes import Canvas, Shape, ShapeCollection, shape  # noqa: F401
+from ._shapes import Canvas, Shape, ShapeCollection, load_shapes, shape  # noqa: F401
 from ._version import __version__  # noqa: F401
 from .color import RGB8  # noqa: F401
 from .image import Image, Resolutions  # noqa: F401
-from .loaders import load_parameters, load_shapes
+from .loaders import load_parameters
 
 Parameters = load_parameters()  # noqa: F401
-Shapes = ShapeCollection(name="lib", collections=load_shapes())  # noqa: F401
+Shapes = load_shapes()  # noqa: F401
 
 # Define some aliases
 S = Shapes  # noqa: F401

--- a/arlunio/_expressions.py
+++ b/arlunio/_expressions.py
@@ -1,0 +1,21 @@
+import functools
+import logging
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+def any(*args):
+    result = functools.reduce(np.logical_or, args)
+    logger.debug(f"any( {', '.join(str(a.shape) for a in args)} ) -> {result.shape}")
+
+    return result
+
+
+def all(*args):
+    return functools.reduce(np.logical_and, args)
+
+
+def invert(x):
+    return np.logical_not(x)

--- a/arlunio/_expressions.py
+++ b/arlunio/_expressions.py
@@ -1,4 +1,5 @@
 import functools
+
 from typing import Union
 
 import numpy as np

--- a/arlunio/_expressions.py
+++ b/arlunio/_expressions.py
@@ -1,19 +1,114 @@
 import functools
-import logging
+from typing import Union
 
 import numpy as np
 
-logger = logging.getLogger(__name__)
+
+def any(*args: Union[bool, np.ndarray]) -> Union[bool, np.ndarray]:
+    """Given a number of conditions, return :code:`True` if any of the conditions
+    are true.
+
+    This function is implemented as a thin wrapper around numpy's
+    :code:`np.logical_or` function so that it can take an arbitrary number of inputs.
+    This also means that this function will accept arrays of differing sizes - assuming
+    that they can be broadcasted to a common shape.
+
+    .. seealso::
+
+       |numpy.Broadcasting|
+          Numpy documentation on broadcasting.
+
+       |numpy.Array Broadcasting|
+          Further background on broadcasting.
+
+       |numpy.logical_or|
+          Reference documentation on the :code:`np.logical_or` function
+
+    :param args: A number of boolean conditions, a condition can either be a single
+                 boolean value or a numpy array of boolean values.
+
+    :Examples:
+
+    >>> import arlunio as ar
+    >>> ar.any(True, False, False)
+    True
+
+    >>> ar.any(False, False, False, False)
+    False
+
+    If the arguments are boolean numpy arrays, then the any condition is applied
+    element-wise
+
+    >>> import numpy as np
+
+    >>> x1 = np.array([True, False, True])
+    >>> x2 = np.array([False, False, True])
+    >>> x3 = np.array([False, True, False])
+
+    >>> ar.any(x1, x2, x3)
+    array([ True,  True,  True])
+
+    This function can even handle a mixture of arrays and single values - assuming
+    their shapes can be broadcasted to a common shape.
+
+    >>> ar.any(False, np.array([True, False]), np.array([[False, True], [True, False]]))
+    array([[ True,  True],
+           [ True, False]])
+    """
+    return functools.reduce(np.logical_or, args)
 
 
-def any(*args):
-    result = functools.reduce(np.logical_or, args)
-    logger.debug(f"any( {', '.join(str(a.shape) for a in args)} ) -> {result.shape}")
+def all(*args: Union[bool, np.ndarray]) -> Union[bool, np.ndarray]:
+    """Given a number of conditions, return :code:`True` only if **all**
+    of the given conditions are true.
 
-    return result
+    This function is implemented as a thin wrapper around numpy's
+    :code:`np.logical_and` function so that it can take an arbitrary number of inputs.
+    This also means that this function will accept arrays of differing sizes - assuming
+    that they can be broadcasted to a common shape.
 
+    .. seealso::
 
-def all(*args):
+       |numpy.Broadcasting|
+          Numpy documentation on broadcasting.
+
+       |numpy.Array Broadcasting|
+          Further background on broadcasting.
+
+       |numpy.logical_and|
+          Reference documentation on the :code:`logical_and` function.
+
+    :param args: A number of boolean conditions, a conditon can either be a single
+                 boolean value, or a numpy array of boolean values.
+
+    :Examples:
+
+    >>> import arlunio as ar
+    >>> ar.all(True, True, True)
+    True
+
+    >>> ar.all(True, False, True, True)
+    False
+
+    If the arguments are boolean numpy arrays, then the any condition is applied
+    element-wise
+
+    >>> import numpy as np
+
+    >>> x1 = np.array([True, False, True])
+    >>> x2 = np.array([False, False, True])
+    >>> x3 = np.array([False, True, True])
+
+    >>> ar.all(x1, x2, x3)
+    array([False, False,  True])
+
+    This function can even handle a mixture of arrays and single values - assuming
+    their shapes can be broadcasted to a common shape.
+
+    >>> ar.all(True, np.array([True, False]), np.array([[False, True], [True, False]]))
+    array([[False, False],
+           [ True, False]])
+    """
     return functools.reduce(np.logical_and, args)
 
 

--- a/arlunio/_shapes.py
+++ b/arlunio/_shapes.py
@@ -54,7 +54,6 @@ class Property:
 class Shape:
     """This is the base class that all shapes inherit from and defines the interface
     that applies to all shapes.
-
     """
 
     scale: float = attr.ib(default=1.0, repr=False)
@@ -77,6 +76,9 @@ class Shape:
     :code:`#ffffff`
     """
 
+    def __attrs_post_init__(self):
+        self._logger = logger.getChild(self.__class__.__name__)
+
     def __add__(self, other):
 
         if isinstance(other, Shape):
@@ -88,6 +90,9 @@ class Shape:
             return other
 
     def __call__(self, width=None, height=None, *, colorspace=None, **kwargs):
+        self._logger.debug("Choosing draw method....")
+        self._logger.debug(f"--> width: {width}, height: {height}")
+        self._logger.debug(f"--> kwargs: {', '.join(kwargs.keys())}")
 
         # If given a width and a height draw the shape as an image.
         if width is not None and height is not None:
@@ -113,6 +118,7 @@ class Shape:
         return self._definition(**args)
 
     def _draw(self, width: int, height: int, colorspace):
+        self._logger.debug(f"Width and Height")
 
         if colorspace is None:
             colorspace = RGB8
@@ -130,13 +136,19 @@ class Shape:
         return image
 
     def mask(self, width: int, height: int):
+        self._logger.debug(f"Mask: {width}x{height}")
 
         args = dict(self.properties)
+        self._logger.debug(f"Properties: {args}")
 
         for param in self.parameters:
             parameter = getattr(Parameter, param)
-            args[param] = parameter(width, height, self.scale)
+            p = parameter(width, height, self.scale)
 
+            self._logger.debug(f"{param}: {p.shape}")
+            args[param] = p
+
+        self._logger.debug(f"Arguments: {', '.join(args.keys())}")
         return self._definition(**args)
 
     @property

--- a/arlunio/_shapes.py
+++ b/arlunio/_shapes.py
@@ -164,10 +164,10 @@ class Shape:
 
         For example the dictionary representation of a circle is::
 
-           >>> import arlunio as st
+           >>> import arlunio as ar
            >>> from pprint import pprint
 
-           >>> circle = st.S.Circle()
+           >>> circle = ar.S.Circle()
            >>> pprint(circle.dict)
            {'color': '#000000',
             'name': 'Circle',
@@ -193,9 +193,9 @@ class Shape:
 
         For example the JSON representation of the circle is::
 
-           >>> import arlunio as st
+           >>> import arlunio as ar
 
-           >>> circle = st.S.Circle()
+           >>> circle = ar.S.Circle()
            >>> print(circle.json)
            {
              "name": "Circle",
@@ -230,7 +230,7 @@ class Shape:
 
         For example we can create an instance of the |Circle| shape as follows::
 
-           >>> import arlunio as st
+           >>> import arlunio as ar
         """
         dictionary = json.loads(json_str)
         return cls.from_dict(dictionary)
@@ -327,9 +327,9 @@ def shape(f) -> type:
     :code:`False` otherwise. The simplest possible shape definition would look
     like the following::
 
-        >>> import arlunio as st
+        >>> import arlunio as ar
 
-        >>> @st.shape
+        >>> @ar.shape
         ... def Everywhere():
         ...     return True
 
@@ -355,7 +355,7 @@ def shape(f) -> type:
     pixel based on its vertical position in the image. Let's create a shape that
     colors in the lower half of the image::
 
-        >>> @st.shape
+        >>> @ar.shape
         ... def LowerHalf(y):
         ...     return y < 0
 
@@ -379,7 +379,7 @@ def shape(f) -> type:
     shape to take a :code:`height` property that we can use to control how much
     of the image we color in::
 
-        >>> @st.shape
+        >>> @ar.shape
         ... def FillHeight(y, *, height=0):
         ...     return y < height
 

--- a/arlunio/doc/__init__.py
+++ b/arlunio/doc/__init__.py
@@ -1,6 +1,7 @@
 import typing
 
 import arlunio
+
 from sphinx.application import Sphinx
 
 from .builder import NotebookTutorialBuilder

--- a/arlunio/doc/builder.py
+++ b/arlunio/doc/builder.py
@@ -2,11 +2,13 @@ import json
 import os
 import re
 import typing
+
 from pathlib import Path
 
 import attr
 import docutils.nodes as nodes
 import docutils.writers as writers
+
 from docutils.io import StringOutput
 from sphinx.builders import Builder
 from sphinx.util import logging

--- a/arlunio/doc/directives.py
+++ b/arlunio/doc/directives.py
@@ -2,10 +2,12 @@ import importlib
 import string
 import textwrap
 import traceback
+
 from typing import List
 
 import arlunio as ar
 import attr
+
 from docutils import nodes
 from docutils.parsers import rst
 from docutils.statemachine import StringList

--- a/arlunio/image.py
+++ b/arlunio/image.py
@@ -98,6 +98,7 @@ class Image:
         return Image(self.pixels[key])
 
     def __setitem__(self, key, value):
+        logger.debug(f"key: {key}")
         self.pixels[key] = value
 
     @property

--- a/arlunio/lib/__init__.py
+++ b/arlunio/lib/__init__.py
@@ -1,1 +1,2 @@
 from .basic import basic  # noqa: F401
+from .pattern import pattern  # noqa: F401

--- a/arlunio/lib/__init__.py
+++ b/arlunio/lib/__init__.py
@@ -1,0 +1,1 @@
+from .basic import basic  # noqa: F401

--- a/arlunio/lib/basic.py
+++ b/arlunio/lib/basic.py
@@ -1,8 +1,10 @@
 import arlunio as ar
 import numpy as np
 
+basic = ar.ShapeCollection(name="basic")
 
-@ar.shape
+
+@basic.shape
 def Circle(x, y, *, x0=0, y0=0, r=0.8, pt=None):
     """We define a circle using the following inequality.
 
@@ -36,7 +38,7 @@ def Circle(x, y, *, x0=0, y0=0, r=0.8, pt=None):
     return np.logical_and(r < circle, circle < R)
 
 
-@ar.shape
+@basic.shape
 def Ellipse(x, y, *, x0=0, y0=0, a=2, b=1, r=0.8, pt=None):
     """An ellipse can be defined using the following inequality.
 
@@ -81,7 +83,7 @@ def Ellipse(x, y, *, x0=0, y0=0, a=2, b=1, r=0.8, pt=None):
     return np.logical_and(r < ellipse, ellipse < R)
 
 
-@ar.shape
+@basic.shape
 def Square(x, y, *, x0=0, y0=0, size=0.8):
     """A square."""
 

--- a/arlunio/lib/basic.py
+++ b/arlunio/lib/basic.py
@@ -6,11 +6,11 @@ basic = ar.ShapeCollection(name="basic")
 
 @basic.shape
 def Circle(x, y, *, x0=0, y0=0, r=0.8, pt=None):
-    """We define a circle using the following inequality.
+    """We define a circle using the following equality.
 
     .. math::
 
-       \\sqrt{(x - x_0)^2 + (y - y_0)^2} < r^2
+       \\sqrt{(x - x_0)^2 + (y - y_0)^2} = r
 
     where:
 
@@ -40,11 +40,12 @@ def Circle(x, y, *, x0=0, y0=0, r=0.8, pt=None):
 
 @basic.shape
 def Ellipse(x, y, *, x0=0, y0=0, a=2, b=1, r=0.8, pt=None):
-    """An ellipse can be defined using the following inequality.
+    """An ellipse can be defined using the following equality.
 
     .. math::
 
-       \\frac{(x - x_0)^2}{a^2} + \\frac{(y - y_0)^2}{b^2} < r^2
+       \\left(\\frac{x - x_0}{a}\\right)^2 +
+       \\left(\\frac{y - y_0}{b}\\right)^2 = r^2
 
     where:
 
@@ -81,6 +82,72 @@ def Ellipse(x, y, *, x0=0, y0=0, a=2, b=1, r=0.8, pt=None):
     r, R = (r - pt / 2) ** 2, (r + pt / 2) ** 2
 
     return np.logical_and(r < ellipse, ellipse < R)
+
+
+@basic.shape
+def SuperEllipse(x, y, *, x0=0, y0=0, a=1, b=1, n=3, r=0.8, m=None, pt=None):
+    """We define a superellipse by the following equality.
+
+    .. math::
+
+       \\left|\\frac{(x - x_0)}{a}\\right|^n + \\left|\\frac{(y - y_0)}{b}\\right|^m = r
+
+    where:
+
+    - :math:`(x_0, y_0)`: Defines the center
+    - :math:`r`: Controls the overall size
+    - :math:`a`: Controls the width
+    - :math:`b`: Controls the height
+    - :math:`n`: Controls the profile of the curve far from :math:`x = 0`
+    - :math:`m`: Controls the profile of the curve close to :math:`x = 0`
+
+    Being a generalisation of an |Ellipse| the :code:`x0`, :code:`y0`, :code:`a`,
+    :code:`b`, :code:`r` and :code:`pt` values behave as they would on a regular
+    ellipse.
+
+    The main difference between a `SuperEllipse`_ and a regular ellipse is the ability
+    to choose the power each term on the |LHS| is raised to. This gives greater control
+    over the profile of the curve that defines the shape. The power can be set
+    independantly for each term through the properties :code:`n` and :code:`m`. If
+    :code:`m` is :code:`None` then the shape will assume you want :math:`m = n` and set
+    the value of :code:`m` accordingly.
+
+    Considering the case where :math:`n = 2 = m`, then we recover the definition of an
+    ellipse. Increasing this value, you will start seeing something that resembles a
+    rectangle with rounded corners, theoretically becoming a rectangle at infinity.
+    However due to limits of the implementation, the size of the shape is hard to
+    control as you go much beyond :code:`10` or :code:`20`. If you want an actual
+    rectangle, then perhaps the |Rectangle| shape is what you are after.
+
+    In the range of :math:`1 \\leq n = m < 2` the "sides" of the ellipse progressively
+    straighten, becoming a diamond shape at :math:`n = 1 = m`
+
+    Finally when the values of both :math:`n,m` are less than one, the sides of the
+    diamond start curving inwards towards the origin, theoretically producing something
+    that looks like a :code:`+` symbol close to (but not equal to!) :code:`0`. Again
+    however, due to limitations of the implementation, the shape becomes harder to
+    control as you get much smaller than :code:`0.2`
+
+    The cases where :math:`n \\neq m` the results are harder to describe! The result
+    will be some combination of the results described above, but you are probably better
+    off experimenting and seeing what comes out of it!
+
+    .. _SuperEllipse: https://en.wikipedia.org/wiki/Superellipse
+
+    """
+
+    xc = x - x0
+    yc = y - y0
+
+    if m is None:
+        m = n
+
+    lhs = np.abs(xc / a) ** n + np.abs(yc / b) ** m
+
+    if pt is not None:
+        return np.logical_and(r - pt / 2 < lhs, lhs < r + pt / 2)
+
+    return lhs < r
 
 
 @basic.shape

--- a/arlunio/lib/basic.py
+++ b/arlunio/lib/basic.py
@@ -33,9 +33,11 @@ def Circle(x, y, *, x0=0, y0=0, r=0.8, pt=None):
     if pt is None:
         return circle < r * r
 
-    r, R = (r - pt) ** 2, (r + pt) ** 2
+    p = r * pt
+    inner = (r - p) ** 2
+    outer = (r + p) ** 2
 
-    return np.logical_and(r < circle, circle < R)
+    return ar.all(inner < circle, circle < outer)
 
 
 @basic.shape
@@ -79,9 +81,11 @@ def Ellipse(x, y, *, x0=0, y0=0, a=2, b=1, r=0.8, pt=None):
     if pt is None:
         return ellipse < r * r
 
-    r, R = (r - pt / 2) ** 2, (r + pt / 2) ** 2
+    p = r * pt
+    inner = (r - p) ** 2
+    outer = (r + p) ** 2
 
-    return np.logical_and(r < ellipse, ellipse < R)
+    return ar.all(inner < ellipse, ellipse < outer)
 
 
 @basic.shape
@@ -142,21 +146,47 @@ def SuperEllipse(x, y, *, x0=0, y0=0, a=1, b=1, n=3, r=0.8, m=None, pt=None):
     if m is None:
         m = n
 
-    lhs = np.abs(xc / a) ** n + np.abs(yc / b) ** m
+    ellipse = np.abs(xc / a) ** n + np.abs(yc / b) ** m
 
-    if pt is not None:
-        return np.logical_and(r - pt / 2 < lhs, lhs < r + pt / 2)
+    if pt is None:
+        return ellipse < r
 
-    return lhs < r
+    p = r * pt
+    inner = r - p
+    outer = r + p
+
+    return ar.all(inner < ellipse, ellipse < outer)
 
 
 @basic.shape
-def Square(x, y, *, x0=0, y0=0, size=0.8):
+def Square(x, y, *, x0=0, y0=0, size=0.8, pt=None):
     """A square."""
 
-    xc = x - x0
-    yc = y - y0
+    xs = np.abs(x - x0)
+    ys = np.abs(y - y0)
 
-    size = size / 2
+    if pt is None:
+        return ar.all(xs < size, ys < size)
 
-    return np.logical_and(np.abs(xc) < size, np.abs(yc) < size)
+    inner = ar.all(xs < size - pt, ys < size - pt)
+    outer = ar.all(xs < size + pt, ys < size + pt)
+
+    return ar.all(outer, ar.invert(inner))
+
+
+@basic.shape
+def Rectangle(x, y, *, x0=0, y0=0, size=0.6, ratio=1.618, pt=None):
+    """A Rectangle."""
+
+    xs = np.abs(x - x0)
+    ys = np.abs(y - y0)
+    width = size * ratio
+    height = size
+
+    if pt is None:
+        return ar.all(xs < width, ys < height)
+
+    inner = ar.all(xs < width - pt, ys < height - pt)
+    outer = ar.all(xs < width + pt, ys < height + pt)
+
+    return ar.all(outer, ar.invert(inner))

--- a/arlunio/lib/basic.py
+++ b/arlunio/lib/basic.py
@@ -1,7 +1,7 @@
 import arlunio as ar
 import numpy as np
 
-basic = ar.ShapeCollection(name="basic")
+basic = ar.ShapeCollection()
 
 
 @basic.shape

--- a/arlunio/lib/pattern.py
+++ b/arlunio/lib/pattern.py
@@ -4,7 +4,7 @@ import arlunio as ar
 import numpy as np
 
 logger = logging.getLogger(__name__)
-pattern = ar.ShapeCollection(name="pattern")
+pattern = ar.ShapeCollection()
 
 
 @pattern.shape

--- a/arlunio/lib/pattern.py
+++ b/arlunio/lib/pattern.py
@@ -1,0 +1,44 @@
+import logging
+
+import arlunio as ar
+import numpy as np
+
+logger = logging.getLogger(__name__)
+pattern = ar.ShapeCollection(name="pattern")
+
+
+@pattern.shape
+def Grid(x, *, nx=4, ny=4, shape=None):
+    """Repeatedly draw the given shape in a grid.
+
+    :param nx: The number of times to repeat the shape in the x-direction
+    :param ny: The number of times to repeat the shape in the y-direction
+    :param shape: The shape instance to draw.
+    """
+
+    # Use a parameter to get the dimensions of the image we are drawing.
+    # Remember! Parameters return an array of (height, width)
+    height, width = x.shape
+    bg = np.full((height, width), False)
+
+    logger.debug(f"Grid size: {ny} x {nx}")
+    logger.debug(f"Background size: {height} x {width}")
+
+    # Draw the shape at a size determined by the size of the grid
+    s_height, s_width = height // ny, width // nx
+    mask = shape.mask(s_width, s_height)
+
+    logger.debug(f"Shape size: {s_height} x {s_width}")
+
+    # Let numpy handle the repeating of the shape across the image.
+    pattern = np.tile(mask, (ny, nx))
+
+    # Apply the pattern to the background, depending on the grid size and
+    # image dimensions align, the generated grid may not perfectly fill the
+    # image.
+    p_height, p_width = pattern.shape
+    logger.debug(f"Pattern size: {p_height} x {p_width}")
+
+    bg[:p_height, :p_width] = pattern
+
+    return bg

--- a/arlunio/loaders.py
+++ b/arlunio/loaders.py
@@ -96,8 +96,9 @@ def load_parameters():
 def load_shapes():
     """Load all of the available shapes."""
 
-    docstring = """\
-    All of the available shapes.
-    """
+    collections = {}
 
-    return _load_collection("Shapes", "arlunio.shapes", docstring)
+    for collection in pkg_resources.iter_entry_points("arlunio.shapes"):
+        collections[collection.name] = collection.load()
+
+    return collections

--- a/arlunio/loaders.py
+++ b/arlunio/loaders.py
@@ -91,14 +91,3 @@ def load_parameters():
     """
 
     return _load_collection("Parameter", "arlunio.parameters", docstring)
-
-
-def load_shapes():
-    """Load all of the available shapes."""
-
-    collections = {}
-
-    for collection in pkg_resources.iter_entry_points("arlunio.shapes"):
-        collections[collection.name] = collection.load()
-
-    return collections

--- a/docs/_definitions.rst
+++ b/docs/_definitions.rst
@@ -13,3 +13,15 @@
 .. Docs References
 
 .. |LHS| replace:: :term:`LHS`
+
+
+.. External Code References
+
+.. |numpy.logical_or| replace:: :data:`np.logical_or <numpy:numpy.logical_or>`
+.. |numpy.logical_and| replace:: :data:`np.logical_and <numpy:numpy.logical_and>`
+
+.. External Doc References
+
+.. |numpy.Broadcasting| replace:: :doc:`Broadcasting <numpy:user/basics.broadcasting>`
+.. |numpy.Array Broadcasting| replace:: :doc:`Array Broadcasting <numpy:user/theory.broadcasting>`
+

--- a/docs/_definitions.rst
+++ b/docs/_definitions.rst
@@ -1,3 +1,11 @@
+.. Code References
+
+.. -- Shapes
 .. |@shape| replace:: :py:func:`@shape <arlunio.shape>`
 .. |Shape| replace:: :py:class:`Shape <arlunio.Shape>`
 .. |Circle| replace:: :py:class:`Circle <arlunio.lib.basic.Circle>`
+.. |Ellipse| replace:: :py:class:`Ellipse <arlunio.lib.basic.Ellipse>`
+
+.. Docs References
+
+.. |LHS| replace:: :term:`LHS`

--- a/docs/_definitions.rst
+++ b/docs/_definitions.rst
@@ -3,8 +3,12 @@
 .. -- Shapes
 .. |@shape| replace:: :py:func:`@shape <arlunio.shape>`
 .. |Shape| replace:: :py:class:`Shape <arlunio.Shape>`
+
 .. |Circle| replace:: :py:class:`Circle <arlunio.lib.basic.Circle>`
 .. |Ellipse| replace:: :py:class:`Ellipse <arlunio.lib.basic.Ellipse>`
+.. |Rectangle| replace:: :py:class:`Rectangle <arlunio.lib.basic.Rectangle>`
+.. |Square| replace:: :py:class:`Square <arlunio.lib.basic.Square>`
+.. |SuperEllipse| replace:: :py:class:`SuperEllipse <arlunio.lib.basic.SuperEllipse>`
 
 .. Docs References
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -1,0 +1,12 @@
+.. _glossary:
+
+Glossary
+========
+
+.. glossary::
+   :sorted:
+
+   LHS
+      The left hand side of an equation/inequality/etc. E.g. in the equation
+      :math:`a^2 + b^2 = c^2`, the left hand side refers to the expression
+      :math:`a^2 + b^2`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-Stylo
-=====
+Arlunio
+=======
 
 .. toctree::
    :maxdepth: 2
@@ -9,4 +9,5 @@ Stylo
    extending/index
    contributing/index
    stdlib/index
+   glossary
    changes

--- a/docs/stdlib/api.rst
+++ b/docs/stdlib/api.rst
@@ -9,6 +9,15 @@ Colour
 .. autoclass:: arlunio.RGB8
    :members:
 
+Expressions
+-----------
+
+.. autofunction:: arlunio.any
+
+.. autofunction:: arlunio.all
+
+.. autofunction:: arlunio.invert
+
 Images
 ------
 

--- a/docs/stdlib/basic-shapes.rst
+++ b/docs/stdlib/basic-shapes.rst
@@ -8,3 +8,5 @@ Basic Shapes
 .. autoshape:: arlunio.lib.basic.Ellipse
 
 .. autoshape:: arlunio.lib.basic.Square
+
+.. autoshape:: arlunio.lib.basic.SuperEllipse

--- a/docs/stdlib/basic-shapes.rst
+++ b/docs/stdlib/basic-shapes.rst
@@ -7,6 +7,8 @@ Basic Shapes
 
 .. autoshape:: arlunio.lib.basic.Ellipse
 
+.. autoshape:: arlunio.lib.basic.Rectangle
+
 .. autoshape:: arlunio.lib.basic.Square
 
 .. autoshape:: arlunio.lib.basic.SuperEllipse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,10 @@ ignore = [
   "tests/*"]
 
 [tool.isort]
-multi_line_output = 3
 include_trailing_comma = true
+line_length = 88
+lines_between_types = 1
+multi_line_output = 3
 
 [tool.tox]
 legacy_tox_ini = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ deps =
      pytest-azurepipelines
 extras = all
 commands =
-    pytest --doctest-modules --doctest-glob="*.rst" --cov=arlunio --cov-report html {posargs}
+    pytest --doctest-modules --doctest-glob="*.rst" --cov=arlunio --cov-report html --cov-report term {posargs}
 
 [testenv:docs]
 deps =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ deps =
      pytest-azurepipelines
 extras = all
 commands =
-    pytest --doctest-glob="*.rst" --cov=arlunio --cov-report html {posargs}
+    pytest --doctest-modules --doctest-glob="*.rst" --cov=arlunio --cov-report html {posargs}
 
 [testenv:docs]
 deps =

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning:jinja2

--- a/setup.py
+++ b/setup.py
@@ -81,10 +81,6 @@ setup(
             "r = arlunio.parameters:rs",
             "t = arlunio.parameters:ts",
         ],
-        "arlunio.shapes": [
-            "Circle = arlunio.lib.basic:Circle",
-            "Ellipse = arlunio.lib.basic:Ellipse",
-            "Square = arlunio.lib.basic:Square",
-        ],
+        "arlunio.shapes": ["basic = arlunio.lib:basic"],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ extras = {
         "pytest-cov",
         "sphinx-autobuild",
         "sphinx_rtd_theme",
+        "sphobjinv",
         "tox",
     ],
     "doc": ["sphinx"],
@@ -81,6 +82,9 @@ setup(
             "r = arlunio.parameters:rs",
             "t = arlunio.parameters:ts",
         ],
-        "arlunio.shapes": ["basic = arlunio.lib:basic"],
+        "arlunio.shapes": [
+            "basic = arlunio.lib:basic",
+            "pattern = arlunio.lib:pattern",
+        ],
     },
 )

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -3,6 +3,7 @@ import unittest.mock as mock
 import pkg_resources
 
 import py.test
+
 from arlunio.loaders import Collection
 
 


### PR DESCRIPTION
- Adds a [SuperEllipse](https://en.wikipedia.org/wiki/Superellipse) shape
- Adds our first "higher order shape"! The `Grid` which given any shape instance, is able to repeat it in an `X x Y` grid on an image
- Adds the concept of a `ShapeCollection`. As the number of shapes grows, it will become harder and harder to find a unique name from which to expose the shape through the `ar.S` object. Each shape collection can also contain other shape collections. Building on this we now have
  + The `ar.S` object is now a shape collection. 
  + Asking for a shape say `ar.S.Circle` if there is a `Circle` object within the current collection then that will be returned. Alternatively if a `Circle` is contained in a sub collection then that would also be returned.
  + In the case of multiple `Circle` objects coming from separate collections, then you will have to include a qualifier to specify which one you are referring to. e.g. `ar.S.std.Circle` vs `ar.S.ext.Circle`
  + To save having to explicitly declare each and every shape a package provides the `arlunio.shapes` entry point now expects instances of a `ShapeCollection` to be declared
- Running tests via `tox` now also tests the docstrings in the codebase
- Tweaks to the documentation 
- Tweaks to some of the existing shape definitons which should hopefully make it easier to control the resulting image 
- Tweaks to some `isort` settings so that it plays nicer with `black`