### PR TITLE
Add Pixelize and Map shapes

### DIFF
--- a/arlunio/lib/pattern.py
+++ b/arlunio/lib/pattern.py
@@ -42,3 +42,44 @@ def Grid(x, *, nx=4, ny=4, shape=None):
     bg[:p_height, :p_width] = pattern
 
     return bg
+
+
+@pattern.shape
+def Map(x, *, layout=None, legend=None):
+    """For more complex layouts."""
+
+    height, width = x.shape
+
+    nx, ny = len(layout), len(layout[0])
+    size = (height // ny, width // nx)  # TODO: Handle divisions with rounding errors
+
+    # Build a new dict with the values being the shapes drawn at the appropriate res
+    # to ensure we only draw them once.
+    items = {k: v.mask(*size) for k, v in legend.items()}
+    return np.block([[items[key] for key in row] for row in layout])
+
+
+@pattern.shape
+def Pixelize(x, *, pixels=None, shape=None, nx=None, ny=None):
+    """Draw a pixelated version of a shape."""
+
+    if shape is None and pixels is None:
+        raise ValueError("You must either provide a shape or a pixel pattern.")
+
+    if shape is not None:
+
+        if nx is None or ny is None:
+            raise ValueError("You must also provide the `nx` and `ny` size parameters")
+
+        pixels = shape.mask(nx, ny)
+
+    nx, ny = len(pixels), len(pixels[0])
+
+    # Get the desired size of the final image.
+    height, width = x.shape
+    size = (height // ny, width // nx)  # TODO: Handle divisions with rounding errors
+
+    fill = np.full(size, True)
+    empty = np.full(size, False)
+
+    return np.block([[fill if col else empty for col in row] for row in pixels])


### PR DESCRIPTION
- The new `Pixelize` shape can take another shape and render a lower res
  version of that shape giving it a pixel art vibe.
- The new `Map` shape can take a grid of values representing some layout
  and a dictionary that maps those values to shapes that should be drawn
  there.