### PR TITLE
Tweaks to enable the gallery

### DIFF
--- a/arlunio/image.py
+++ b/arlunio/image.py
@@ -2,6 +2,7 @@ import base64
 import enum
 import io
 import logging
+import pathlib
 import string
 
 import numpy as np
@@ -153,11 +154,16 @@ class Image:
             "RGB", (width, height), self.pixels, "raw", "RGB", 0, 1
         )
 
-    def save(self, filename: str) -> None:
+    def save(self, filename: str, mkdirs: bool = False) -> None:
         """Save an image in PNG format.
 
         :param filename: The filepath to save the image to.
+        :param mkdirs: If true, make any parent directories
         """
+        path = pathlib.Path(filename)
+
+        if not path.parent.exists() and mkdirs:
+            path.parent.mkdir(parents=True)
 
         image = self._as_pillow_image()
 

--- a/arlunio/imp/__init__.py
+++ b/arlunio/imp/__init__.py
@@ -28,7 +28,12 @@ def find_notebook(fullname, path=None):
     """Converts a.b.c into a valid filepath and checks to see if it exists."""
 
     name = fullname.rsplit(".", 1)[-1]
-    path = [""] if not path else path
+
+    if path is None:
+        path = [""]
+
+    if isinstance(path, str):
+        path = [path]
 
     logger.debug("path: %s", path)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 filterwarnings =
     ignore::DeprecationWarning:jinja2
-norecursedirs = .dev build dist *.egg
+testpaths = tests docs


### PR DESCRIPTION
- Add `mkdirs` flag to the `Image.save` function to have the option of automatically creating any required parent directories
- Tweak the `find_notebook` function to handle the way we are using it in the gallery
- Explicitly list the folders that contain tests so that `pytest` doesn't try to load the gallery code when running the test suite 