### PR TITLE
Add the ability to load a notebook from a filepath

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ deps =
      pytest-cov
 extras = all
 commands =
-    pytest --doctest-modules --doctest-glob="*.rst" --ignore=blog/* --cov=arlunio --cov-report term {posargs}
+    pytest --doctest-modules --doctest-glob="*.rst" --cov=arlunio --cov-report term {posargs}
 
 [testenv:docs]
 deps =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+import os
+
+import py.test
+
+
+@py.test.fixture(scope="session")
+def testdata():
+    """Given the name of a file in the data/ folder return its contents.
+
+    Alternatively if the :code:`path_only` option is set just return the full
+    path to it.
+    """
+
+    basepath = os.path.join(os.path.dirname(__file__), "data")
+
+    def loader(filename, path_only=False):
+
+        filepath = os.path.join(basepath, filename)
+
+        if path_only:
+            return filepath
+
+        with open(filepath, "rb") as f:
+            return f.read()
+
+    return loader

--- a/tests/data/Add.ipynb
+++ b/tests/data/Add.ipynb
@@ -1,0 +1,35 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def add(x, y):\n",
+    "    return x + y"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/data/Metadata.ipynb
+++ b/tests/data/Metadata.ipynb
@@ -1,0 +1,49 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is an example of a notebook that carries additional metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def add(*args):\n",
+    "    return sum(args)"
+   ]
+  }
+ ],
+ "metadata": {
+  "arlunio": {
+   "author": "Alex",
+   "dimensions": [
+    1920,
+    1080
+   ]
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/data/Pythagoras.ipynb
+++ b/tests/data/Pythagoras.ipynb
@@ -1,0 +1,46 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Pythaoras Theorem states that given a right angled triangle with sides \\\\(a\\\\), \\\\(b\\\\), \\\\(c\\\\) then\n",
+    "the following relationship holds\n",
+    "\\\\[\n",
+    "    a^2 + b^2 = c^2\n",
+    "\\\\]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def pythagoras(a, b):\n",
+    "    return a**2 + b**2"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/imp/test_loader.py
+++ b/tests/imp/test_loader.py
@@ -1,0 +1,45 @@
+import math
+
+import py.test
+
+from arlunio.imp import NotebookLoader
+
+
+def test_notebook_loader_simple(testdata):
+    """Ensure that we can load a simple notebook that only contains code cells"""
+
+    nbpath = testdata("Add.ipynb", path_only=True)
+    notebook = NotebookLoader.fromfile(nbpath)
+
+    assert 3 == notebook.add(1, 2)
+
+
+def test_notebook_loader(testdata):
+    """Ensure that we can load a notebook that contains a mixture of cell types."""
+
+    nbpath = testdata("Pythagoras.ipynb", path_only=True)
+    notebook = NotebookLoader.fromfile(nbpath)
+
+    assert 5 == math.sqrt(notebook.pythagoras(3, 4))
+
+
+def test_notebook_loader_metadata(testdata):
+    """Ensure that we can access a notebook's metadata"""
+
+    nbpath = testdata("Metadata.ipynb", path_only=True)
+    notebook = NotebookLoader.fromfile(nbpath)
+
+    assert 6 == notebook.add(1, 2, 3)
+
+    assert [1920, 1080] == notebook.__notebook__.metadata.arlunio.dimensions
+    assert "Alex" == notebook.__notebook__.metadata.arlunio.author
+
+
+def test_notebook_loader_checks_existance(testdata):
+    """Ensure that the notebook loader checks to see if the given notebook exists,
+    raising a helpful error if it doesn't."""
+
+    with py.test.raises(FileNotFoundError) as err:
+        NotebookLoader.fromfile("not-found.ipynb")
+
+    assert "not-found.ipynb" in str(err.value)


### PR DESCRIPTION
- New `NotebookLoader.fromfile` classmethod that handles the specifics of importing a notebook from a given filepath
- Added a `testdata` fixture that gives test code easy access to test data
- Added some tests around importing notebooks