### PR TITLE
The beginnings of the parameter system!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,8 @@
 .cache
 .coverage
 .hypothesis
-.idea
 .ipynb_checkpoints/
+.scratch
 .pytest_cache
 .tox
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "python",
+            "request": "launch",
+            "name": "Pytest: Current File",
+            "program": "${workspaceFolder}/.dev/bin/pytest",
+            "args": [
+                "${file}"
+            ]
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,13 +14,15 @@
         "coverage.xml": true,
         "test-output.xml": true
     },
-    "python.pythonPath": "${workspaceFolder}/.dev/bin/python",
+    "python.autoComplete.addBrackets": true,
+    "python.formatting.provider": "black",
     "python.linting.pylintEnabled": false,
     "python.linting.flake8Enabled": true,
     "python.linting.enabled": true,
-    "python.autoComplete.addBrackets": true,
+    "python.pythonPath": "${workspaceFolder}/.dev/bin/python",
+    "python.terminal.activateEnvInCurrentTerminal": true,
+    "python.terminal.activateEnvironment": true,
     "python.testing.pytestEnabled": true,
-    "python.formatting.provider": "black",
     "restructuredtext.confPath": "${workspaceFolder}/docs",
     "[css]": {
         "editor.tabSize": 2

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -90,6 +90,16 @@
             }
         },
         {
+            "label": "Scratch Notebooks",
+            "type": "shell",
+            "command": "source ${workspaceRoot}/.dev/bin/activate && jupyter-lab",
+            "problemMatcher": [],
+            "group": "build",
+            "options": {
+                "cwd": "${workspaceRoot}/.scratch"
+            }
+        },
+        {
             "label": "Test File",
             "type": "shell",
             "command": "${config:python.pythonPath} -m tox -e py38 -- ${file}",

--- a/arlunio/__init__.py
+++ b/arlunio/__init__.py
@@ -1,4 +1,5 @@
 from ._color import RGB8  # noqa: F401
+from ._core import Collection  # noqa: F401
 from ._expressions import all, any, invert  # noqa: F401
 from ._image import Image, Resolutions  # noqa: F401
 from ._loaders import load_parameters

--- a/arlunio/__init__.py
+++ b/arlunio/__init__.py
@@ -2,6 +2,8 @@ from ._color import RGB8  # noqa: F401
 from ._expressions import all, any, invert  # noqa: F401
 from ._image import Image, Resolutions  # noqa: F401
 from ._loaders import load_parameters
+from ._parameters import Parameters as P  # noqa: F401
+from ._parameters import parameter  # noqa: F401
 from ._shapes import Canvas, Shape, ShapeCollection, load_shapes, shape  # noqa: F401
 from ._version import __version__  # noqa: F401
 

--- a/arlunio/_core.py
+++ b/arlunio/_core.py
@@ -1,0 +1,141 @@
+from typing import Any, Dict
+
+import attr
+
+
+class Key:
+    """This class is used to represent x.y.z keys in a collection.
+
+    It's only a thin wrapper around a tuple that should make the implementation of
+    collections easier to reason about. A key can be created from a number of strings
+
+    >>> from arlunio._shapes import Key
+    >>> Key('a', 'b', 'c')
+    k'a.b.c'
+
+    Alternatively from a single string with each part delimited with a dot.
+
+    >>> Key.fromstring('a.b.c')
+    k'a.b.c'
+
+    Keys have a length which is equal to the number of components that makes up the
+    key.
+
+    >>> k = Key('a', 'b', 'c')
+    >>> len(k)
+    3
+
+    They can be checked to see if they are equal against other keys, or their string
+    representation
+
+    >>> k == Key.fromstring('a.b.c')
+    True
+
+    >>> k == "a.b.c"
+    True
+
+    Keys can be indexed
+
+    >>> k[0]
+    'a'
+
+    But not mutated
+
+    >>> k[1] = 'd'
+    Traceback (most recent call last):
+        ...
+    TypeError: 'Key' object does not support item assignment
+    """
+
+    __slots__ = "_key"
+
+    def __init__(self, *args):
+        self._key = args
+
+    def __repr__(self):
+        return f"k'{str(self)}'"
+
+    def __str__(self):
+        return ".".join(self._key)
+
+    def __hash__(self):
+        return hash(self._key)
+
+    def __eq__(self, other):
+
+        if isinstance(other, Key):
+            return self._key == other._key
+
+        if isinstance(other, str):
+            return str(self) == other
+
+        return False
+
+    def __len__(self):
+        return len(self._key)
+
+    def __getitem__(self, index):
+        return self._key[index]
+
+    def __add__(self, other):
+        return Key.fromstring(str(self) + "." + str(other))
+
+    @classmethod
+    def fromstring(cls, string):
+        return cls(*string.split("."))
+
+
+@attr.s(auto_attribs=True)
+class Collection:
+    """A group of related items, indexed by keys."""
+
+    _items: Dict[Key, Any] = attr.Factory(dict)
+
+    def __str__(self):
+        sep = "\n|  "
+        name = self.__class__.__name__
+        header = f"{name}: {len(self)} items{sep}"
+        items = sep.join(str(k) for k in self._items.keys())
+
+        return header + items
+
+    def __len__(self):
+        return len(self._items)
+
+    def __getitem__(self, key):
+
+        if isinstance(key, int):
+            return list(self._items.values())[key]
+
+        raise KeyError(key)
+
+    def __getattr__(self, name):
+        candidates = self.find(name)
+        cls = self.__class__
+
+        if len(candidates) == 0:
+            items = {k: v for k, v in self._items.items() if k[0] == name}
+
+            if len(items) == 0:
+                raise AttributeError(f"No item with name: {name}")
+
+            return cls(items=items)
+
+        if len(candidates) == 1:
+            return candidates[0]
+
+        raise AttributeError(f"Ambiguous reference: {name}")
+
+    def find(self, name: str):
+        """Return a collection of all the items that have the given name."""
+
+        items = {k: v for k, v in self._items.items() if k[-1] == name}
+        return Collection(items=items)
+
+    def merge(self, prefix: str, collection) -> None:
+        """Given a collection and a prefix, merge its items into the collection."""
+
+        prefix = Key.fromstring(prefix)
+
+        for k, item in collection._items.items():
+            self._items[prefix + k] = item

--- a/arlunio/_parameters.py
+++ b/arlunio/_parameters.py
@@ -1,0 +1,45 @@
+import inspect
+
+from typing import ClassVar
+
+import attr
+
+from ._core import Collection, Key
+
+
+@attr.s(auto_attribs=True)
+class Parameter:
+    META_ID: ClassVar[str] = "arlunio.parameter.attribute"
+
+    def __call__(self, width: int, height: int):
+        return self._definition(width, height)
+
+
+# The default parameter collection
+Parameters = Collection()
+
+
+def parameter(f=None, *, collection=None):
+    """Define a new parameter."""
+
+    if collection is None:
+        collection = Parameters
+
+    def wrapper(pdef):
+
+        name = pdef.__name__
+        attributes = {
+            "__doc__": inspect.getdoc(pdef),
+            "_definition": staticmethod(pdef),
+        }
+
+        p = attr.s(type(name, (Parameter,), attributes))
+        collection._items[Key.fromstring(name)] = p
+
+        return p
+
+    # Allow the decorator to be used with or without a function call
+    if f is None:
+        return wrapper
+
+    return wrapper(f)

--- a/arlunio/_parameters.py
+++ b/arlunio/_parameters.py
@@ -1,10 +1,20 @@
 import inspect
 
-from typing import ClassVar
+from typing import Any, ClassVar, Dict, List
 
 import attr
 
 from ._core import Collection, Key
+
+
+def _prepare_parameter(param, attribs):
+    """Given a parameter and a bag of attributes, create an instance of it passing the
+    right attributes into the constructor."""
+
+    names = {a.name for a in attr.fields(param) if a.metadata[Parameter.ATTR_ID]}
+    args = {name: attribs[name] for name in names}
+
+    return param(**args)
 
 
 @attr.s(auto_attribs=True)
@@ -14,6 +24,7 @@ class Parameter:
 
     def __call__(self, width: int, height: int):
         args = dict(self.parameters)
+        attribs = self.attributes
 
         for name in args:
 
@@ -25,15 +36,28 @@ class Parameter:
                 args[name] = height
                 continue
 
-        return self._definition(**args, **self.attributes)
+            # Else it must be a derived parameter so evaluate it...
+            p = _prepare_parameter(args[name], attribs)
+            args[name] = p(width, height)
+
+        return self._definition(**args, **self.attribs)
 
     @property
     def attributes(self):
-        fields = attr.fields(self.__class__)
+        """All attributes for the parameter definition."""
         return {
             a.name: getattr(self, a.name)
-            for a in fields
+            for a in attr.fields(self.__class__)
             if Parameter.ATTR_ID in a.metadata
+        }
+
+    @property
+    def attribs(self):
+        """Any non-inherited attributes for the parameter definition."""
+        return {
+            a.name: getattr(self, a.name)
+            for a in attr.fields(self.__class__)
+            if not a.metadata[Parameter.ATTR_ID]["inherited"]
         }
 
 
@@ -43,13 +67,82 @@ def _define_attribute(param: inspect.Parameter) -> attr.Attribute:
     """
 
     args = {"default": param.default, "kw_only": True}
-    args["metadata"] = {Parameter.ATTR_ID: True}
+    args["metadata"] = {Parameter.ATTR_ID: {"inherited": False}}
 
     if param.annotation != inspect.Parameter.empty:
         args["type"] = param.annotation
         args["validator"] = [attr.validators.instance_of(param.annotation)]
 
     return attr.ib(**args)
+
+
+def _inherit_attributes(param: Parameter, attributes):
+    """Given a parameter and the attributes dict for the parameter under construction,
+    inherit its attributes."""
+
+    # Only look at the fields that have been defined to be a parameter attribute
+    for attrib in (a for a in attr.fields(param) if a.metadata[Parameter.ATTR_ID]):
+
+        # For now skip any attributes that have already been defined.
+        if attrib.name in attributes:
+            continue
+
+        metadata = dict(**attrib.metadata)
+        metadata[Parameter.ATTR_ID] = {"inherited": True}
+
+        # It seems that the best way to copy an attrs attribute from one class to
+        # another is to construct a fresh instance based on source...
+        attributes[attrib.name] = attr.ib(
+            converter=attrib.converter,
+            default=attrib.default,
+            kw_only=attrib.kw_only,
+            repr=False,
+            metadata=metadata,
+            validator=attrib.validator,
+        )
+
+
+def _process_parameters(
+    signature: inspect.Signature, attributes: Dict[str, Any]
+) -> List[inspect.Parameter]:
+    """Check each of the input parameters in the definition and process them.
+
+    First this function checks to see if the inputs are either a known base parameter
+    e.g. :code:`width` or :code:`height`. Or otherwise the input carries a type
+    annotation declaring what parameter it represents.
+
+    Once it has checked that the input parameters are well defined, it adds additional
+    attribute definitions to expose the attributes of the parameter
+    """
+
+    # Determine which of the args in the signature are not attributes
+    params = [p for p in signature.values() if p.name not in attributes]
+
+    # We will build a list of all the parameter definitions that this parameter is
+    # derived from.
+    param_definitions = []
+
+    for param in params:
+
+        if param.annotation == inspect.Parameter.empty:
+            if param.name in {"width", "height"}:
+                continue
+
+            raise TypeError(f"Unknown parameter '{param.name}''")
+
+        if not issubclass(param.annotation, Parameter):
+            raise TypeError(
+                f"Invalid input '{param.name}', type '{param.annotation.__name__}'"
+                " is not a Parameter"
+            )
+
+        param_definitions.append(param.annotation)
+
+    # For each of the parameters we derive from, inherit its attributes
+    for pdef in param_definitions:
+        _inherit_attributes(pdef, attributes)
+
+    return params
 
 
 # The default parameter collection
@@ -70,16 +163,17 @@ def parameter(f=None, *, collection=None):
         signature = inspect.signature(pdef).parameters
 
         attrs = [attr for attr in signature.values() if attr.kind == kw_only]
-        params = [param for param in signature.values() if param not in attrs]
 
         attributes = {
             "__doc__": inspect.getdoc(pdef),
             "_definition": staticmethod(pdef),
-            "parameters": {p.name: p.annotation for p in params},
         }
 
         for a in attrs:
             attributes[a.name] = _define_attribute(a)
+
+        params = _process_parameters(signature, attributes)
+        attributes["parameters"] = {p.name: p.annotation for p in params}
 
         p = attr.s(type(name, (Parameter,), attributes))
         collection._items[Key.fromstring(name)] = p

--- a/arlunio/_parameters.py
+++ b/arlunio/_parameters.py
@@ -12,7 +12,19 @@ class Parameter:
     META_ID: ClassVar[str] = "arlunio.parameter.attribute"
 
     def __call__(self, width: int, height: int):
-        return self._definition(width, height)
+        args = dict(self.parameters)
+
+        for name in args:
+
+            if name == "width" and args[name] == inspect.Parameter.empty:
+                args[name] = width
+                continue
+
+            if name == "height" and args[name] == inspect.Parameter.empty:
+                args[name] = height
+                continue
+
+        return self._definition(**args)
 
 
 # The default parameter collection
@@ -28,9 +40,17 @@ def parameter(f=None, *, collection=None):
     def wrapper(pdef):
 
         name = pdef.__name__
+
+        kw_only = inspect.Parameter.KEYWORD_ONLY
+        signature = inspect.signature(pdef).parameters
+
+        attrs = [attr for attr in signature.values() if attr.kind == kw_only]
+        params = [param for param in signature.values() if param not in attrs]
+
         attributes = {
             "__doc__": inspect.getdoc(pdef),
             "_definition": staticmethod(pdef),
+            "parameters": {p.name: p.annotation for p in params},
         }
 
         p = attr.s(type(name, (Parameter,), attributes))

--- a/arlunio/_shapes.py
+++ b/arlunio/_shapes.py
@@ -3,13 +3,14 @@ import json
 import logging
 import re
 
-from typing import Any, Dict, List
+from typing import Any, List
 
 import pkg_resources
 
 import attr
 
 from ._color import RGB8
+from ._core import Collection, Key
 from ._image import Image
 from ._loaders import load_parameters
 
@@ -426,144 +427,6 @@ def shape(f) -> type:
         define_property(prop, attributes)
 
     return attr.s(type(name, (Shape,), attributes))
-
-
-class Key:
-    """This class is used to represent x.y.z keys in a collection.
-
-    It's only a thin wrapper around a tuple that should make the implementation of
-    collections easier to reason about. A key can be created from a number of strings
-
-    >>> from arlunio._shapes import Key
-    >>> Key('a', 'b', 'c')
-    k'a.b.c'
-
-    Alternatively from a single string with each part delimited with a dot.
-
-    >>> Key.fromstring('a.b.c')
-    k'a.b.c'
-
-    Keys have a length which is equal to the number of components that makes up the
-    key.
-
-    >>> k = Key('a', 'b', 'c')
-    >>> len(k)
-    3
-
-    They can be checked to see if they are equal against other keys, or their string
-    representation
-
-    >>> k == Key.fromstring('a.b.c')
-    True
-
-    >>> k == "a.b.c"
-    True
-
-    Keys can be indexed
-
-    >>> k[0]
-    'a'
-
-    But not mutated
-
-    >>> k[1] = 'd'
-    Traceback (most recent call last):
-        ...
-    TypeError: 'Key' object does not support item assignment
-    """
-
-    __slots__ = "_key"
-
-    def __init__(self, *args):
-        self._key = args
-
-    def __repr__(self):
-        return f"k'{str(self)}'"
-
-    def __str__(self):
-        return ".".join(self._key)
-
-    def __hash__(self):
-        return hash(self._key)
-
-    def __eq__(self, other):
-
-        if isinstance(other, Key):
-            return self._key == other._key
-
-        if isinstance(other, str):
-            return str(self) == other
-
-        return False
-
-    def __len__(self):
-        return len(self._key)
-
-    def __getitem__(self, index):
-        return self._key[index]
-
-    def __add__(self, other):
-        return Key.fromstring(str(self) + "." + str(other))
-
-    @classmethod
-    def fromstring(cls, string):
-        return cls(*string.split("."))
-
-
-@attr.s(auto_attribs=True)
-class Collection:
-    """A group of related items, indexed by keys."""
-
-    _items: Dict[Key, Any] = attr.Factory(dict)
-
-    def __str__(self):
-        sep = "\n|  "
-        name = self.__class__.__name__
-        header = f"{name}: {len(self)} items{sep}"
-        items = sep.join(str(k) for k in self._items.keys())
-
-        return header + items
-
-    def __len__(self):
-        return len(self._items)
-
-    def __getitem__(self, key):
-
-        if isinstance(key, int):
-            return list(self._items.values())[key]
-
-        raise KeyError(key)
-
-    def __getattr__(self, name):
-        candidates = self.find(name)
-        cls = self.__class__
-
-        if len(candidates) == 0:
-            items = {k: v for k, v in self._items.items() if k[0] == name}
-
-            if len(items) == 0:
-                raise AttributeError(f"No item with name: {name}")
-
-            return cls(items=items)
-
-        if len(candidates) == 1:
-            return candidates[0]
-
-        raise AttributeError(f"Ambiguous reference: {name}")
-
-    def find(self, name: str):
-        """Return a collection of all the items that have the given name."""
-
-        items = {k: v for k, v in self._items.items() if k[-1] == name}
-        return Collection(items=items)
-
-    def merge(self, prefix: str, collection) -> None:
-        """Given a collection and a prefix, merge its items into the collection."""
-
-        prefix = Key.fromstring(prefix)
-
-        for k, item in collection._items.items():
-            self._items[prefix + k] = item
 
 
 class ShapeCollection(Collection):

--- a/arlunio/lib/parameters.py
+++ b/arlunio/lib/parameters.py
@@ -1,3 +1,4 @@
+import arlunio as ar
 import numpy as np
 
 
@@ -37,3 +38,56 @@ def ts(width, height, scale=1):
     y = ys(width, height, scale)
 
     return np.arctan2(y, x)
+
+
+@ar.parameter
+def X(width, height, *, scale=1, stretch=False):
+    """Cartesian :math:`x` coordinates.
+
+    :param scale: Controls the size of the extreme values in the grid.
+    :param stretch: If :code:`True` and the image is wider than it is tall then the grid
+                    will be stretched so that :code:`x = scale` falls on the image
+                    border.
+    """
+    ratio = width / height
+
+    if not stretch and ratio > 1:
+        scale = scale * ratio
+
+    x = np.linspace(-scale, scale, width)
+    x = np.array([x for _ in range(height)])
+
+    return x
+
+
+@ar.parameter
+def Y(width, height, *, scale=1, stretch=False):
+    """Cartesian :math:`y` coordinates.
+
+    :param scale: Controls the size of the extreme values in the grid
+    :param stretch: If :code:`True` and the image is taller than it is wide then the
+                    grid will be stretched so that :code:`y = scale` falls on the image
+                    border
+    """
+    ratio = height / width
+
+    if not stretch and ratio > 1:
+        scale = scale * ratio
+
+    y = np.linspace(scale, -scale, height)
+    y = np.array([y for _ in range(width)]).transpose()
+
+    return y
+
+
+@ar.parameter
+def R(x: X, y: Y):
+    """Polar :math:`r` coordinates."""
+    return np.sqrt(x * x + y * y)
+
+
+@ar.parameter
+def T(x: X, y: Y, *, t0=0):
+    """Polar, :math:`t` coordinates."""
+    t = np.arctan2(y, x)
+    return t - t0

--- a/arlunio/testing/__init__.py
+++ b/arlunio/testing/__init__.py
@@ -1,0 +1,4 @@
+from hypothesis.strategies import floats, integers
+
+pve_num = floats(min_value=1, max_value=1e6)
+dimension = integers(min_value=4, max_value=512)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ isolated_build = True
 
 [testenv]
 deps =
+     hypothesis
      pytest
      pytest-cov
 extras = all

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ extras = {
     ],
     "doc": ["sphinx"],
     "examples": ["jupyterlab"],
+    "testing": ["hypothesis"],
 }
 
 extras["all"] = list(

--- a/tests/lib/test_parameters.py
+++ b/tests/lib/test_parameters.py
@@ -1,0 +1,90 @@
+import arlunio.testing as T
+import numpy as np
+import py.test
+
+from arlunio.lib.parameters import X, Y
+from hypothesis import assume, given
+
+
+@given(width=T.dimension, height=T.dimension)
+def test_X_matches_dimension(width, height):
+    """Ensure that the output shape matches the width and height of the image"""
+
+    x = X()
+    assert x(width, height).shape == (height, width)
+
+
+@given(width=T.dimension, height=T.dimension)
+def test_X_uniform_vertically(width, height):
+    """Ensure that the output only varies in the x-direction"""
+
+    x = X()
+    xs = x(width, height)
+
+    assert np.unique(xs, axis=0).shape == (1, width)
+
+
+@given(width=T.dimension, height=T.dimension, scale=T.pve_num)
+def test_X_adapts_to_image_ratio_by_default(width, height, scale):
+    """Ensure that the output adapts to the aspect ratio of the image."""
+
+    assume(width / height > 1)
+
+    x = X(scale=scale)
+    xs = x(width, height)
+
+    assert width / height == py.test.approx(np.max(xs) / scale)
+
+
+@given(width=T.dimension, height=T.dimension, scale=T.pve_num)
+def test_X_fits_to_image_size_when_told(width, height, scale):
+    """Ensure that the output fits to the size of the image when :code:`fit` property
+    is set."""
+
+    x = X(scale=scale, stretch=True)
+    xs = x(width, height)
+
+    assert np.max(xs) == scale
+
+
+@given(width=T.dimension, height=T.dimension)
+def test_Y_matches_dimension(width, height):
+    """Ensure that the output shape matches the width and height of the image."""
+
+    y = Y()
+    ys = y(width, height)
+
+    assert ys.shape == (height, width)
+
+
+@given(width=T.dimension, height=T.dimension)
+def test_Y_uniform_horizontally(width, height):
+    """Ensure that the output only varies in the y direction"""
+
+    y = Y()
+    ys = y(width, height)
+
+    assert np.unique(ys, axis=1).shape == (height, 1)
+
+
+@given(width=T.dimension, height=T.dimension, scale=T.pve_num)
+def test_Y_adapts_to_image_ratio_by_default(width, height, scale):
+    """Ensure that the output adapts to the aspect ratio of the image"""
+
+    assume(height / width > 1)
+
+    y = Y(scale=scale)
+    ys = y(width, height)
+
+    assert height / width == py.test.approx(np.max(ys) / scale)
+
+
+@given(width=T.dimension, height=T.dimension, scale=T.pve_num)
+def test_Y_fits_to_image_size_when_told(width, height, scale):
+    """Ensure that the output fits to the size of the image when :code:`fit` property
+    is set."""
+
+    y = Y(scale=scale, stretch=True)
+    ys = y(width, height)
+
+    assert np.max(ys) == scale

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,21 +1,28 @@
 import arlunio as ar
+import py.test
+
+
+@py.test.fixture()
+def collection():
+    """An empty collection for each test case."""
+    return ar.Collection()
 
 
 def test_use_parameter_as_tag():
     """Ensure that the parameter decorator can be used as a simple tag."""
 
     @ar.parameter
-    def Param(width, height):
+    def z123_(width, height):
         return width
 
-    p = Param()
+    p = z123_()
     assert p(4, 2) == 4
 
 
-def test_use_parameter_as_function():
+def test_use_parameter_as_function(collection):
     """Ensure that the parameter decorator can be used as a function."""
 
-    @ar.parameter()
+    @ar.parameter(collection=collection)
     def Param(width, height):
         return height
 
@@ -23,12 +30,76 @@ def test_use_parameter_as_function():
     assert p(4, 2) == 2
 
 
-def test_parameter_constant():
-    """Ensure that we can define as constant parameter."""
+def test_parameter_default_collection():
+    """Ensure that if we don't specify a collection the parameter will be added to the
+    default one."""
 
     @ar.parameter
+    def x123_P():
+        return 0
+
+    assert x123_P == ar.P.x123_P
+
+
+def test_parameter_with_collection():
+    """Ensure that if a collection is given the parameter will be added to the given
+    collection."""
+
+    my_collection = ar.Collection()
+
+    @ar.parameter(collection=my_collection)
+    def Param(width):
+        return width
+
+    with py.test.raises(AttributeError) as err:
+        ar.P.Param
+
+    assert "Param" in str(err.value)
+    assert my_collection.Param == Param
+
+
+def test_parameter_constant(collection):
+    """Ensure that we can define as constant parameter."""
+
+    @ar.parameter(collection=collection)
     def Constant():
         return 1
 
     const = Constant()
     assert const(10, 10) == 1
+
+
+def test_parameter_width_only(collection):
+    """Ensure that we can define a parameter with respect to width only."""
+
+    @ar.parameter(collection=collection)
+    def Width(width):
+        return width + 1
+
+    w = Width()
+    assert w(100, 2) == 101
+
+
+def test_parameter_height_only(collection):
+    """Ensure that we can define a parameter with respect to height only."""
+
+    @ar.parameter(collection=collection)
+    def Height(height):
+        return height - 1
+
+    h = Height()
+    assert h(2, 100) == 99
+
+
+def test_parameter_attributes(collection):
+    """Ensure that we can define a parameter that takes a number of attributes."""
+
+    @ar.parameter(collection=collection)
+    def Param(width, height, *, offset=0):
+        return (width + height) - offset
+
+    p = Param()
+    assert p(1, 1) == 2
+
+    q = Param(offset=2)
+    assert q(1, 1) == 0

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,0 +1,34 @@
+import arlunio as ar
+
+
+def test_use_parameter_as_tag():
+    """Ensure that the parameter decorator can be used as a simple tag."""
+
+    @ar.parameter
+    def Param(width, height):
+        return width
+
+    p = Param()
+    assert p(4, 2) == 4
+
+
+def test_use_parameter_as_function():
+    """Ensure that the parameter decorator can be used as a function."""
+
+    @ar.parameter()
+    def Param(width, height):
+        return height
+
+    p = Param()
+    assert p(4, 2) == 2
+
+
+def test_parameter_constant():
+    """Ensure that we can define as constant parameter."""
+
+    @ar.parameter
+    def Constant():
+        return 1
+
+    const = Constant()
+    assert const(10, 10) == 1


### PR DESCRIPTION
- Add a formal parameter system to `arlunio`
- Parameters are inputs to shapes that are dependent on the dimensions of the image being drawn. The typical use case for parameters so far has been to map a cartesian/polar coordinate system onto the pixels of an image in order for shapes to be defined w.r.t those coordinates.
- The new system adds an `@ar.parameter` decorator that will automatically define parameters based on the decorated function. See `arlunio/lib/parameters.py` for examples. 
- Highlights of the new system
  + Like shapes, parameters can take attributes as keyword only arguments
  + Support for derived parameters - i.e. instead of `width` and `height` as the input we could take other parameters that have already been defined. Any attributes in base parameters are automatically exposed on the generated class for the new parameter

**Future Work**
- So far the new system has not been integrated with the shapes system

**Other Changes**
- Add a dedicated `.gitignore`d folder for scratch, experimental notebooks
- Add VSCode task to launch notebook server in the scratch folder
- Add VSCode launch config to debug the current test file
- Tweak to some python specific VSCode settings