### PR TITLE
Improvements to the cli interface generator

### DIFF
--- a/arlunio/cli/__init__.py
+++ b/arlunio/cli/__init__.py
@@ -56,7 +56,7 @@ def build_dummy_command_parser(
 
     e_type, e_val, tb = err
 
-    message = "WARNING Command unavailable: " + str(err)
+    message = "Command unavailable: " + str(e_val)
     parser = parent.add_parser(name, help=message)
     parser.add_argument("collector", nargs=argparse.REMAINDER)
 
@@ -94,7 +94,10 @@ def _register_commands(parent: argparse._SubParsersAction, entry_point: str):
     In the case where a command cannot be loaded, this function will put a dummy command
     in its place so that we can gracefully handle it and inform the user.
     """
-    for cmd in pkg_resources.iter_entry_points(entry_point):
+    commands = sorted(
+        list(pkg_resources.iter_entry_points(entry_point)), key=lambda c: c.name
+    )
+    for cmd in commands:
         try:
             command = cmd.load()
             build_command_parser(cmd.name, command, parent)

--- a/arlunio/cli/_interface.py
+++ b/arlunio/cli/_interface.py
@@ -107,10 +107,13 @@ class CliCommand:
         if not hasattr(cmd, "run") or not callable(cmd.run):
             raise TypeError("Missing expected method: 'run'")
 
+        docstring = inspect.getdoc(cmd)
+        summary = "..." if docstring is None else docstring.split("\n")[0]
+
         params = {
             "name": name,
             "options": CliOption.frommethod(cmd.run),
-            "summary": inspect.getdoc(cmd).split("\n")[0],
+            "summary": summary,
         }
 
         return cls(**params)

--- a/arlunio/cli/_interface.py
+++ b/arlunio/cli/_interface.py
@@ -107,7 +107,13 @@ class CliCommand:
         if not hasattr(cmd, "run") or not callable(cmd.run):
             raise TypeError("Missing expected method: 'run'")
 
-        params = {"name": name, "options": CliOption.frommethod(cmd.run)}
+        print()
+
+        params = {
+            "name": name,
+            "options": CliOption.frommethod(cmd.run),
+            "summary": inspect.getdoc(cmd).split("\n")[0],
+        }
 
         return cls(**params)
 
@@ -123,7 +129,7 @@ def build_command_parser(
     """
     cmd = CliCommand.fromcmd(name, command)
     parser = parent.add_parser(
-        cmd.name, formatter_class=argparse.RawDescriptionHelpFormatter
+        cmd.name, help=cmd.summary, formatter_class=argparse.RawDescriptionHelpFormatter
     )
 
     names = []

--- a/arlunio/cli/_interface.py
+++ b/arlunio/cli/_interface.py
@@ -107,8 +107,6 @@ class CliCommand:
         if not hasattr(cmd, "run") or not callable(cmd.run):
             raise TypeError("Missing expected method: 'run'")
 
-        print()
-
         params = {
             "name": name,
             "options": CliOption.frommethod(cmd.run),

--- a/tests/cli/test_interface.py
+++ b/tests/cli/test_interface.py
@@ -129,12 +129,18 @@ def test_single_cmd_run_attribute():
 
 
 class AddCommand:
+    """A single line summary.
+
+    Further information on usage follows
+    """
+
     def run(self, x: int, y: int = 1):
         pass
 
 
 ADD_COMMAND = CliCommand(
     name="test",
+    summary="A single line summary.",
     options=[
         CliOption(name="--x", args=INT_NO_DEFAULT),
         CliOption(name="--y", args=INT_WITH_DEFAULT(1)),


### PR DESCRIPTION
- Ensure subcommands are sorted by name
- Easier to read error messages in subcommand help summaries
- Include the first line of the command's docstring as a summary