### PR TITLE
Add method to get return type

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "Build Blog",
             "type": "shell",
-            "command": "${config:python.pythonPath} gallery.py --local",
+            "command": "${config:python.pythonPath} gallery.py ${input:blogArgs}",
             "problemMatcher": [],
             "group": "build",
             "presentation": {
@@ -17,24 +17,6 @@
                 "showReuseMessage": false,
                 "clear": true
             },
-            "options": {
-                "cwd": "${workspaceRoot}/blog"
-            }
-        },
-        {
-            "label": "Build Blog (debug)",
-            "type": "shell",
-            "command": "${config:python.pythonPath} gallery.py -vv --local",
-            "problemMatcher": [],
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": false,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": true
-            },
-            "group": "build",
             "options": {
                 "cwd": "${workspaceRoot}/blog"
             }
@@ -165,6 +147,30 @@
                 }
             ],
             "default": "-e py38"
+        },
+        {
+            "id": "blogArgs",
+            "description": "Blog Arguments",
+            "type": "pickString",
+            "options": [
+                {
+                    "label": "Local",
+                    "value": "--local"
+                },
+                {
+                    "label": "Local, skipping errors",
+                    "value": "--local --skip-failures"
+                },
+                {
+                    "label": "Local, debug",
+                    "value": "-vv --local"
+                },
+                {
+                    "label": "Local, debug, skipping errors",
+                    "value": "-vv --local --skip-failures"
+                }
+            ],
+            "default": "--local"
         }
     ]
 }

--- a/arlunio/__init__.py
+++ b/arlunio/__init__.py
@@ -1,4 +1,4 @@
 from ._core import Collection, Definition, definition  # noqa: F401
 from ._expressions import all, any, clamp, invert, lerp  # noqa: F401
-from ._images import Resolutions, colorramp, encode, fill, save  # noqa: F401
+from ._images import Image, Resolutions, colorramp, encode, fill, save  # noqa: F401
 from ._version import __version__  # noqa: F401

--- a/arlunio/_core.py
+++ b/arlunio/_core.py
@@ -207,6 +207,16 @@ class Definition:
             if not a.metadata[Definition.ATTR_ID]["inherited"]
         }
 
+    @classmethod
+    def produces(cls):
+        """Return the type of the object that this definition produces."""
+        rtype = inspect.signature(cls._definition).return_annotation
+
+        if rtype == inspect._empty:
+            return Any
+
+        return rtype
+
 
 def _define_attribute(param: inspect.Parameter) -> attr.Attribute:
     """Given a parameter that represents some definition's attribute, write the

--- a/arlunio/_images.py
+++ b/arlunio/_images.py
@@ -7,12 +7,15 @@ import pathlib
 from typing import Optional
 
 import numpy as np
-import PIL.Image as Image
-import PIL.ImageColor as Color
+import PIL.Image as PImage
+import PIL.ImageColor as PColor
 
 from ._expressions import lerp
 
 logger = logging.getLogger(__name__)
+
+# Create a type alias that we're free to change in the future
+Image = PImage.Image
 
 
 class Resolutions(enum.Enum):
@@ -87,26 +90,26 @@ def encode(image) -> bytes:
         return base64.b64encode(image_bytes)
 
 
-def colorramp(values, start=None, stop=None):
+def colorramp(values, start: Optional[str] = None, stop: Optional[str] = None) -> Image:
     """Given a range of values, produce an image mapping those values onto colors."""
 
-    (r, g, b) = Color.getrgb("#000") if start is None else Color.getrgb(start)
-    (R, G, B) = Color.getrgb("#fff") if stop is None else Color.getrgb(stop)
+    (r, g, b) = PColor.getrgb("#000") if start is None else PColor.getrgb(start)
+    (R, G, B) = PColor.getrgb("#fff") if stop is None else PColor.getrgb(stop)
 
     reds = np.floor(lerp(r, R)(values))
     greens = np.floor(lerp(g, G)(values))
     blues = np.floor(lerp(b, B)(values))
 
     pixels = np.array(np.dstack([reds, greens, blues]), dtype=np.uint8)
-    return Image.fromarray(pixels)
+    return PImage.fromarray(pixels)
 
 
 def fill(
     mask,
     color: Optional[str] = None,
     background: Optional[str] = None,
-    image: Optional[Image.Image] = None,
-) -> Image.Image:
+    image: Optional[Image] = None,
+) -> Image:
     """Given a mask, fill it in with a color.
 
     Parameters
@@ -127,21 +130,21 @@ def fill(
 
     Returns
     -------
-    PIL.Image.Image
+    Image
         An image with the region selected by the mask colored with the given color
 
     """
 
     color = "#000" if color is None else color
-    fill_color = Color.getrgb(color)
+    fill_color = PColor.getrgb(color)
 
-    mask_img = Image.fromarray(mask)
+    mask_img = PImage.fromarray(mask)
 
     if image is None:
         background = "#fff" if background is None else background
 
         height, width = mask.shape
-        image = Image.new("RGB", (width, height), color=background)
+        image = PImage.new("RGB", (width, height), color=background)
 
     else:
         image = image.copy()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,7 @@
 import inspect
 
+from typing import Any
+
 import arlunio as ar
 import py.test
 
@@ -93,6 +95,30 @@ def test_definition_attribute_validation():
 
     with py.test.raises(TypeError):
         Param(a="string")
+
+
+def test_definition_produces_any():
+    """Ensure that a definition without a return annotation reports its return type as
+    :code:`Any`"""
+
+    @ar.definition()
+    def Param():
+        pass
+
+    assert Param.produces() == Any
+    assert Param().produces() == Any
+
+
+def test_definition_produces():
+    """Ensure that a definition reports what type it returns as declared by its return
+    annotation"""
+
+    @ar.definition()
+    def Param() -> int:
+        return 1
+
+    assert Param.produces() == int
+    assert Param().produces() == int
 
 
 def test_derived_definition():


### PR DESCRIPTION
- Definitions now have a method `produces` which can be used to get the return type of a definition, it returns `typing.Any` is a return annotation is not given
- Alias pillow image `ar.Image`, which gives us the ability to change the representation in the future
- Parameterise build blog vscode task definition