### PR TITLE
Attempt to fix release workflow bugs

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -166,7 +166,7 @@ jobs:
       run: |
         python -m pip install towncrier docutils
 
-        ./scripts/write-release-notes.sh > release-notes.html
+        ./scripts/write-release-notes.sh $VERSION > release-notes.html
         notes=$(cat release-notes.html)
         echo $notes
 

--- a/scripts/should-release.sh
+++ b/scripts/should-release.sh
@@ -15,7 +15,6 @@ echo
 
 if [ -z "$changes" ]; then
     echo "There is nothing to do."
-    echo "::set-output name=should_release::false"
 else
     echo "Changes detected, cutting release!"
     echo "::set-output name=should_release::true"

--- a/scripts/write-release-notes.sh
+++ b/scripts/write-release-notes.sh
@@ -10,8 +10,8 @@
 # - Strip all class="x" declarations
 # - Strip all id="x" declarations
 # - Escape all '"' characters so we hopefully produce valid JSON
-towncrier --draft | rst2html.py --template=changes/github-template.html \
-                  | tr -d '\n' \
-                  | sed 's/ class="[^"]*"//g' \
-                  | sed 's/ id="[^"]*"//g' \
-                  | sed 's.".\\".g'
+towncrier --draft --version='$1' | rst2html.py --template=changes/github-template.html \
+                                 | tr -d '\n' \
+                                 | sed 's/ class="[^"]*"//g' \
+                                 | sed 's/ id="[^"]*"//g' \
+                                 | sed 's.".\\".g'


### PR DESCRIPTION
- Pass the `VERSION` env var to `write-release-notes.sh`
- Explicitly pass the version to towncrier, hopefully that stops it trying to import arlunio
- Try not setting any output if there is no reason to make a release and see if that falsifies the `if` expressions