### PR TITLE
Generalise definition inputs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,9 @@ include LICENSE
 include CHANGES.rst
 include README.md
 include pyproject.toml
+
 recursive-include arlunio *.sh
 recursive-include arlunio *.ipynb
 recursive-include arlunio *.py
+
+recursive-exclude tests *.py

--- a/arlunio/__init__.py
+++ b/arlunio/__init__.py
@@ -1,4 +1,4 @@
-from ._core import Defn, Mask, definition  # noqa: F401
+from ._core import Defn, DefnInput, Mask, definition  # noqa: F401
 from ._expressions import all, any, clamp, invert, lerp, normalise  # noqa: F401
 from ._images import Image, Resolutions, colorramp, encode, fill, save  # noqa: F401
 from ._version import __version__  # noqa: F401

--- a/arlunio/_core.py
+++ b/arlunio/_core.py
@@ -1,23 +1,16 @@
 import inspect
+import logging
 
 from typing import Any, ClassVar, Dict, List, Optional
 
 import attr
 
+logger = logging.getLogger(__name__)
+
 
 class Mask:
     """Currently just a type alias for boolean numpy arrays but gives us the flexibility
     to add smarts later."""
-
-
-def _prepare_definition(defn, attributes):
-    """Given a definiton and a bag of attributes, create an instance of it by passing
-    in the applicable attributes into the constructor."""
-
-    names = {a.name for a in attr.fields(defn) if a.metadata[Defn.ATTR_ID]}
-    args = {name: attributes[name] for name in names}
-
-    return defn(**args)
 
 
 def _format_type(obj: Optional[Any] = None, type_: Optional[Any] = None) -> str:
@@ -66,8 +59,9 @@ class _BaseDefn(type):
 
 @attr.s(auto_attribs=True)
 class Defn(metaclass=_BaseDefn):
-    """A definition is the representation of something that can be mapped onto an
-    image."""
+    """Defn, short for 'Definition' is the object that powers the rest of
+    :code:`arlunio`.
+    """
 
     ATTR_ID: ClassVar[str] = "arlunio.attribute"
 
@@ -85,34 +79,58 @@ class Defn(metaclass=_BaseDefn):
     OP_SUB: ClassVar[str] = "subtraction"
     OP_XOR: ClassVar[str] = "exclusive_or"
 
-    def __call__(self, width: int = None, height: int = None, **kwargs):
-        args = dict(self.definitions)
+    def __call__(self, *pos, **kwargs):
+        logger.debug("Evaluating definition: '%s'", self.__class__.__name__)
+        logger.debug("--> Positional Args: %s", pos)
+        logger.debug("--> Keyword arguments: %s", kwargs)
+
+        # Requiring inputs to be given as kw args makes the api less sensitive to
+        # changes in the implementation
+        if len(pos) != 0:
+            raise TypeError("Definition inputs must be passed as keyword arguments")
+
+        required = self.inputs(inherited=False)
+        missing = ["'" + n + "'" for n in required.keys() if n not in kwargs]
+
+        logger.debug("Preparing arguments")
+        logger.debug("--> Directly required inputs: %s", list(required.keys()))
+
+        if len(missing) != 0:
+            name = self.__class__.__name__
+            inpts = ", ".join(missing)
+            message = f"Unable to evaluate definition '{name}', missing inputs: {inpts}"
+
+            raise TypeError(message)
+
+        # Start building a dict for the args to pass to the _impl function. Starting
+        # with the actual values of the required inputs
+        args = {inpt: kwargs[inpt] for inpt in required}
+
+        # Now to evaluate any definitions this definition is derived from.
         attributes = self.attributes(inherited=True)
+        bases = dict(self._bases)
 
-        try:
-            width, height = width
-        except TypeError:
-            pass
+        logger.debug("--> Attributes: %s", attributes)
+        logger.debug("--> Bases: %s", bases)
 
-        for name in args:
-
-            if name == "width" and args[name] == inspect.Parameter.empty:
-                args[name] = width
-                continue
-
-            if name == "height" and args[name] == inspect.Parameter.empty:
-                args[name] = height
-                continue
+        for name, defn in bases.items():
 
             if name in kwargs:
+                logger.debug("%s: Using user provided override, %s", name, kwargs[name])
                 args[name] = kwargs[name]
                 continue
 
-            # Else it must be a definition so let's evaluate it
-            defn = _prepare_definition(args[name], attributes)
-            args[name] = defn(width, height)
+            attrs = {name: attributes[name] for name in defn.attribs(inherited=True)}
+            instance = defn(**attrs)
+            logger.debug("%s: Created instance, %s")
 
-        return self._definition(**args, **self.attributes())
+            # And then evaluate it!
+            args[name] = instance(**kwargs)
+
+        message = "Executing implementation for '%s' with args: %s"
+        logger.debug(message, self.__class__.__name__, args)
+
+        return self._impl(**args, **self.attributes())
 
     def _special_method(self, operation, a, b):
         """Implements the special methods in a standardized way."""
@@ -255,14 +273,51 @@ class Defn(metaclass=_BaseDefn):
         }
 
     @classmethod
+    def bases(cls):
+        """Return all the definitions this defintion is derived from."""
+        return dict(cls._bases)
+
+    @classmethod
+    def inputs(cls, inherited=True):
+        """Return all the inputs required to evaluate this definition.
+
+        Parameters
+        ----------
+        inherited:
+            If :code:`True` (default) also return any inherited inputs.
+        """
+        if inherited:
+            return {k: v for k, v in cls._inputs.items()}
+
+        return {k: v for k, v in cls._inputs.items() if not v.inherited}
+
+    @classmethod
     def produces(cls):
         """Return the type of the object that this definition produces."""
-        rtype = inspect.signature(cls._definition).return_annotation
+        rtype = inspect.signature(cls._impl).return_annotation
 
         if rtype == inspect._empty:
             return Any
 
         return rtype
+
+
+@attr.s(auto_attribs=True)
+class DefnInput:
+    """A class that represents an input to a definition"""
+
+    name: str
+    """The name of the input."""
+
+    dtype: Any
+    """The type of the input"""
+
+    inherited: bool
+    """Flag to indicate if the input has been inherited from another definition."""
+
+    sources: Optional[List[Defn]] = None
+    """List of definitions to indicate which definitions an input has been inherited
+    from."""
 
 
 def _define_attribute(param: inspect.Parameter) -> attr.Attribute:
@@ -313,44 +368,78 @@ def _inherit_attributes(defn: Defn, attributes):
         )
 
 
+def _inherit_inputs(defn: Defn, inputs):
+    """Given a definition and the inputs for the current definition under construction
+    copy over its inputs.
+
+    Parameters
+    ----------
+    defn:
+        The definition to inherit inputs from
+    inputs:
+        The dictionary carrying the inputs for the definition under construction.
+    """
+    logger.debug("Inherting inputs from definition: %s", defn.__name__)
+
+    for name, inpt in defn.inputs().items():
+
+        if name in inputs and inputs[name].inherited:
+            inputs[name].sources.append(defn)
+            logger.debug("%s: inherited input, updated", name)
+            continue
+
+        if name in inputs:
+            logger.debug("%s: already defined, skipping", name)
+            continue
+
+        # Otherwise we now need to mark this input as being inherited
+        inputs[name] = DefnInput(
+            name=name, dtype=inpt.dtype, inherited=True, sources=[defn]
+        )
+
+        logger.debug("%s: inherited input, new", name)
+
+
 def _process_parameters(
     signature: inspect.Signature, attributes: Dict[str, Any]
 ) -> List[inspect.Parameter]:
     """Ensure that the input parameters for the defintion are well defined.
 
-    First this function will ensure any of the parameters that are not a known "base"
-    (e.g. :code:`width` or :code:`height`) are instead a known :code:`Defn`.
-    For any definitions that are referenced, their attributes are then exposed to the
-    definition under construction.
+    All parameters must carry a type annotation, if the annotation is not a
+    Defn the parameter will be registered as an input that must be given when
+    evaluating a definiton.
+
+    Otherwise if the annotation is another definition then both the inputs and
+    attributes of that definition will be inherited.
     """
 
     # Input parameters are any arguments that are not attributes
     params = [p for p in signature.values() if p.name not in attributes]
 
-    # We will hold a list of definitions we are based on.
-    defns = []
+    # We will hold a dict of definitions we are based on.
+    defns = {}
+
+    # As well as a dict of inputs required to evaluate the definiton.
+    inputs = {}
 
     for param in params:
 
         if param.annotation == inspect.Parameter.empty:
-            if param.name in {"width", "height"}:
-                continue
+            raise TypeError(f"Missing type annotation for parameter '{param.name}'")
 
-            raise TypeError(f"Unknown input '{param.name}'")
+        if issubclass(param.annotation, Defn):
+            defns[param.name] = param.annotation
+            continue
 
-        if not issubclass(param.annotation, Defn):
-            raise TypeError(
-                f"Invalid input '{param.name}', type '{param.annotation.__name__}'"
-                " is not a Defn"
-            )
+        inpt = DefnInput(name=param.name, dtype=param.annotation, inherited=False)
+        inputs[inpt.name] = inpt
 
-        defns.append(param.annotation)
-
-    # Now for each definition, inherit its attributes.
-    for defn in defns:
+    # Now for each definition, inherit its attributes and inputs.
+    for defn in defns.values():
         _inherit_attributes(defn, attributes)
+        _inherit_inputs(defn, inputs)
 
-    return params
+    return defns, inputs
 
 
 _OPERATOR_POOL = {}
@@ -390,8 +479,8 @@ def _define_operator(defn: Defn, operation: str, operator_pool):
     operator_pool[key] = defn
 
 
-def definition(f=None, operation: str = None, operator_pool=None):
-    """Create a new Defn.
+def definition(f=None, *, operation: str = None, operator_pool=None):
+    """Create a new Definition.
 
     Parameters
     ----------
@@ -416,15 +505,16 @@ def definition(f=None, operation: str = None, operator_pool=None):
         attributes = {
             "__doc__": inspect.getdoc(fn),
             "__module__": fn.__module__,
-            "_definition": staticmethod(fn),
+            "_impl": staticmethod(fn),
             "_operators": operators,
         }
 
         for a in attrs:
             attributes[a.name] = _define_attribute(a)
 
-        params = _process_parameters(signature, attributes)
-        attributes["definitions"] = {p.name: p.annotation for p in params}
+        bases, inputs = _process_parameters(signature, attributes)
+        attributes["_bases"] = bases
+        attributes["_inputs"] = inputs
 
         defn = attr.s(type(name, (Defn,), attributes))
 

--- a/arlunio/_core.py
+++ b/arlunio/_core.py
@@ -275,6 +275,10 @@ class Defn(metaclass=_BaseDefn):
     @classmethod
     def bases(cls):
         """Return all the definitions this defintion is derived from."""
+
+        if not hasattr(cls, "_bases"):
+            return {}
+
         return dict(cls._bases)
 
     @classmethod
@@ -286,6 +290,9 @@ class Defn(metaclass=_BaseDefn):
         inherited:
             If :code:`True` (default) also return any inherited inputs.
         """
+        if not hasattr(cls, "_inputs"):
+            return {}
+
         if inherited:
             return {k: v for k, v in cls._inputs.items()}
 

--- a/arlunio/doc/__init__.py
+++ b/arlunio/doc/__init__.py
@@ -70,7 +70,6 @@ def _process_docstring(
         inherits = _document_inheritance(obj)
 
         if inherits is not None:
-            print("\n".join(inherits))
 
             for l in reversed(inherits):
                 lines.insert(0, l)

--- a/arlunio/doc/__init__.py
+++ b/arlunio/doc/__init__.py
@@ -1,4 +1,5 @@
 import inspect
+import textwrap
 
 from typing import Any, Dict, List, Optional
 
@@ -15,27 +16,50 @@ from .directives import (
     visit_nbtutorial,
 )
 
+# fmt: off
+TEMPLATE = [
+    ".. list-table::",
+    "   :widths: 5 20",
+    "   :header-rows: 0",
+    "",
+]
+# fmt: on
 
-def _document_inheritance(defn: arlunio.Defn) -> Optional[str]:
+
+def _document_inheritance(defn: arlunio.Defn) -> Optional[List[str]]:
     """Given a definition, link back to any definitions it derives from."""
 
-    if not hasattr(defn, "definitions"):
-        return None
+    lines = []
+    inputs = []
+    defns = []
 
-    defs = []
+    for name, value in defn.inputs().items():
+        dtype = value.dtype
 
-    for name, value in defn.definitions.items():
+        if hasattr(value.dtype, "__name__"):
+            dtype = dtype.__name__
 
-        if value == inspect._empty:
-            defs.append(name)
-            continue
+        inputs.append(f":code:`{name}: {dtype}`")
+
+    if len(inputs) > 0:
+        lines.append(textwrap.indent("* - **Inputs:**", " " * 3))
+        lines.append(textwrap.indent(", ".join(inputs), " " * 5 + "- "))
+
+    for name, value in defn.bases().items():
 
         name = value.__name__
         mod = value.__module__
 
-        defs.append(f":class:`{name} <{mod}.{name}>`")
+        defns.append(f":class:`{name} <{mod}.{name}>`")
 
-    return f"*Derives from:* {', '.join(defs)}"
+    if len(defns) > 0:
+        lines.append(textwrap.indent("* - **Bases:**", " " * 3))
+        lines.append(textwrap.indent(", ".join(defns), " " * 5 + "- "))
+
+    if len(lines) == 0:
+        return None
+
+    return list(TEMPLATE) + lines + ["", ""]
 
 
 def _process_docstring(
@@ -46,8 +70,10 @@ def _process_docstring(
         inherits = _document_inheritance(obj)
 
         if inherits is not None:
-            lines.insert(0, "")
-            lines.insert(0, inherits)
+            print("\n".join(inherits))
+
+            for l in reversed(inherits):
+                lines.insert(0, l)
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:

--- a/arlunio/lib/operators.py
+++ b/arlunio/lib/operators.py
@@ -4,7 +4,7 @@ from arlunio import Defn, Mask
 
 
 @ar.definition(operation=Defn.OP_ADD)
-def MaskAdd(width, height, *, a: Defn[Mask] = None, b: Defn[Mask] = None):
+def MaskAdd(width: int, height: int, *, a: Defn[Mask] = None, b: Defn[Mask] = None):
     """Add any two mask producing definitions together.
 
     The resulting defintion will return a mask that is :code:`True` if a given point
@@ -52,7 +52,7 @@ def MaskAdd(width, height, *, a: Defn[Mask] = None, b: Defn[Mask] = None):
 
 
 @ar.definition(operation=Defn.OP_SUB)
-def MaskSub(width, height, *, a: Defn[Mask] = None, b: Defn[Mask] = None):
+def MaskSub(width: int, height: int, *, a: Defn[Mask] = None, b: Defn[Mask] = None):
     """Subtract one mask away from another mask.
 
     The resulting definition will return a mask that is :code:`True` only if a given
@@ -104,7 +104,7 @@ def MaskSub(width, height, *, a: Defn[Mask] = None, b: Defn[Mask] = None):
 
 
 @ar.definition(operation=Defn.OP_MUL)
-def MaskMul(width, height, *, a: Defn[Mask] = None, b: Defn[Mask] = None):
+def MaskMul(width: int, height: int, *, a: Defn[Mask] = None, b: Defn[Mask] = None):
     """Muliply any two mask producing definitions together.
 
     The resulting definition will return a mask that is :code:`True` only if a given

--- a/arlunio/lib/operators.py
+++ b/arlunio/lib/operators.py
@@ -31,7 +31,7 @@ def MaskAdd(width: int, height: int, *, a: Defn[Mask] = None, b: Defn[Mask] = No
        c2 = Circle(xc=0.25, yc=0.25, r=0.7)
 
        c = c1 + c2
-       image = ar.fill(c(1920,1080))
+       image = ar.fill(c(width=1920, height=1080))
 
     Or can be used directly
 
@@ -45,10 +45,10 @@ def MaskAdd(width: int, height: int, *, a: Defn[Mask] = None, b: Defn[Mask] = No
        b = Circle(xc=0.25, yc=0.25, r=0.7)
 
        c = MaskAdd(a=a, b=b)
-       image = ar.fill(c(1920, 1080))
+       image = ar.fill(c(width=1920, height=1080))
     """
 
-    return ar.any(a(width, height), b(width, height))
+    return ar.any(a(width=width, height=height), b(width=width, height=height))
 
 
 @ar.definition(operation=Defn.OP_SUB)
@@ -84,7 +84,7 @@ def MaskSub(width: int, height: int, *, a: Defn[Mask] = None, b: Defn[Mask] = No
        c2 = Circle(xc=0.25, yc=0.25, r=0.7)
 
        c = c1 - c2
-       image = ar.fill(c(1920,1080))
+       image = ar.fill(c(width=1920, height=1080))
 
     Or can be used directly
 
@@ -92,15 +92,17 @@ def MaskSub(width: int, height: int, *, a: Defn[Mask] = None, b: Defn[Mask] = No
        :include-code: before
 
        import arlunio as ar
-       from arlunio.lib import Circle, MaskMul, Square
+       from arlunio.lib import Circle, MaskSub, Square
 
        a = Square(xc=-0.25, yc=-0.25, size=0.55)
        b = Circle(xc=0.25, yc=0.25, r=0.7)
 
-       c = MaskMul(a=b, b=a)
-       image = ar.fill(c(1920, 1080))
+       c = MaskSub(a=b, b=a)
+       image = ar.fill(c(width=1920, height=1080))
     """
-    return ar.all(a(width, height), ar.invert(b(width, height)))
+    return ar.all(
+        a(width=width, height=height), ar.invert(b(width=width, height=height))
+    )
 
 
 @ar.definition(operation=Defn.OP_MUL)
@@ -131,7 +133,7 @@ def MaskMul(width: int, height: int, *, a: Defn[Mask] = None, b: Defn[Mask] = No
        c2 = Circle(xc=0.25, yc=0.25, r=0.7)
 
        c = c1 * c2
-       image = ar.fill(c(1920,1080))
+       image = ar.fill(c(width=1920, height=1080))
 
     Or can be used directly
 
@@ -145,6 +147,6 @@ def MaskMul(width: int, height: int, *, a: Defn[Mask] = None, b: Defn[Mask] = No
        b = Circle(xc=0.25, yc=0.25, r=0.7)
 
        c = MaskMul(a=a, b=b)
-       image = ar.fill(c(1920, 1080))
+       image = ar.fill(c(width=1920, height=1080))
     """
-    return ar.all(a(width, height), b(width, height))
+    return ar.all(a(width=width, height=height), b(width=width, height=height))

--- a/arlunio/lib/parameters.py
+++ b/arlunio/lib/parameters.py
@@ -11,7 +11,7 @@ def X(width: int, height: int, *, x0=0, scale=1, stretch=False):
        from arlunio.lib import X
 
        x = X()
-       image = ar.colorramp(x(1920, 1080))
+       image = ar.colorramp(x(width=1920, height=1080))
 
     Cartesian :math:`x` coordinates.
 
@@ -34,7 +34,7 @@ def X(width: int, height: int, *, x0=0, scale=1, stretch=False):
 
        >>> from arlunio.lib import X
        >>> x = X()
-       >>> x(4,4)
+       >>> x(width=4, height=4)
        array([[-1.        , -0.33333333,  0.33333333,  1.        ],
               [-1.        , -0.33333333,  0.33333333,  1.        ],
               [-1.        , -0.33333333,  0.33333333,  1.        ],
@@ -43,14 +43,14 @@ def X(width: int, height: int, *, x0=0, scale=1, stretch=False):
     If however the image is wider than it is tall this range will be extended so that
     the resulting image is not stretched::
 
-       >>> x(4, 2)
+       >>> x(width=4, height=2)
        array([[-2.        , -0.66666667,  0.66666667,  2.        ],
               [-2.        , -0.66666667,  0.66666667,  2.        ]])
 
     This behaviour can be disabled with the :code:`stretch` attribute::
 
        >>> x.stretch = True
-       >>> x(4,2)
+       >>> x(width=4, height=2)
        array([[-1.        , -0.33333333,  0.33333333,  1.        ],
               [-1.        , -0.33333333,  0.33333333,  1.        ]])
 
@@ -59,7 +59,7 @@ def X(width: int, height: int, *, x0=0, scale=1, stretch=False):
     the values by a given amount::
 
        >>> x = X(x0=-2, scale=2)
-       >>> x(4,4)
+       >>> x(width=4, height=4)
        array([[0.        , 1.33333333, 2.66666667, 4.        ],
               [0.        , 1.33333333, 2.66666667, 4.        ],
               [0.        , 1.33333333, 2.66666667, 4.        ],
@@ -86,7 +86,7 @@ def Y(width: int, height: int, *, y0=0, scale=1, stretch=False):
        from arlunio.lib import Y
 
        y = Y()
-       image = ar.colorramp(y(1920, 1080))
+       image = ar.colorramp(y(width=1920, height=1080))
 
     Cartesian :math:`y` coordinates.
 
@@ -109,7 +109,7 @@ def Y(width: int, height: int, *, y0=0, scale=1, stretch=False):
 
        >>> from arlunio.lib import Y
        >>> y = Y()
-       >>> y(4,4)
+       >>> y(width=4, height=4)
        array([[ 1.        ,  1.        ,  1.        ,  1.        ],
               [ 0.33333333,  0.33333333,  0.33333333,  0.33333333],
               [-0.33333333, -0.33333333, -0.33333333, -0.33333333],
@@ -118,7 +118,7 @@ def Y(width: int, height: int, *, y0=0, scale=1, stretch=False):
     If however the image is taller than it is wide this range will be extended so that
     the resulting image is not stretched::
 
-       >>> y(2, 4)
+       >>> y(width=2, height=4)
        array([[ 2.        ,  2.        ],
               [ 0.66666667,  0.66666667],
               [-0.66666667, -0.66666667],
@@ -127,7 +127,7 @@ def Y(width: int, height: int, *, y0=0, scale=1, stretch=False):
     This behaviour can be disabled with the :code:`stretch` attribute::
 
        >>> y.stretch = True
-       >>> y(2,4)
+       >>> y(width=2, height=4)
        array([[ 1.        ,  1.        ],
               [ 0.33333333,  0.33333333],
               [-0.33333333, -0.33333333],
@@ -138,7 +138,7 @@ def Y(width: int, height: int, *, y0=0, scale=1, stretch=False):
     the values by a given amount::
 
        >>> y = Y(y0=-2, scale=2)
-       >>> y(4,4)
+       >>> y(width=4, height=4)
        array([[4.        , 4.        , 4.        , 4.        ],
               [2.66666667, 2.66666667, 2.66666667, 2.66666667],
               [1.33333333, 1.33333333, 1.33333333, 1.33333333],
@@ -165,7 +165,7 @@ def R(x: X, y: Y):
        from arlunio.lib import R
 
        r = R()
-       image = ar.colorramp(r(1920,1080))
+       image = ar.colorramp(r(width=1920, height=1080))
 
     Polar :math:`r` coordinates.
 
@@ -182,7 +182,7 @@ def R(x: X, y: Y):
 
        >>> from arlunio.lib import R
        >>> r = R()
-       >>> r(5,5)
+       >>> r(width=5, height=5)
        array([[1.41421356, 1.11803399, 1.        , 1.11803399, 1.41421356],
               [1.11803399, 0.70710678, 0.5       , 0.70710678, 1.11803399],
               [1.        , 0.5       , 0.        , 0.5       , 1.        ],
@@ -194,7 +194,7 @@ def R(x: X, y: Y):
     from these base definitions::
 
        >>> r = R(x0=-2, y0=-2, scale=2)
-       >>> r(5,5)
+       >>> r(width=5, height=5)
        array([[4.        , 4.12310563, 4.47213595, 5.        , 5.65685425],
               [3.        , 3.16227766, 3.60555128, 4.24264069, 5.        ],
               [2.        , 2.23606798, 2.82842712, 3.60555128, 4.47213595],
@@ -218,7 +218,7 @@ def T(x: X, y: Y, *, t0=0):
        from arlunio.lib import T
 
        t = T()
-       image = ar.colorramp(t(1920, 1080))
+       image = ar.colorramp(t(width=1920, height=1080))
 
     Polar, :math:`t` coordinates.
 
@@ -242,7 +242,7 @@ def T(x: X, y: Y, *, t0=0):
 
        >>> from arlunio.lib import T
        >>> t = T()
-       >>> t(5,5)
+       >>> t(width=5, height=5)
        array([[ 2.35619449,  2.03444394,  1.57079633,  1.10714872,  0.78539816],
               [ 2.67794504,  2.35619449,  1.57079633,  0.78539816,  0.46364761],
               [ 3.14159265,  3.14159265,  0.        ,  0.        ,  0.        ],
@@ -253,7 +253,7 @@ def T(x: X, y: Y, *, t0=0):
 
        >>> from math import pi
        >>> t.t0 = pi
-       >>> t(5,5)
+       >>> t(width=5, height=5)
        array([[-0.78539816, -1.10714872, -1.57079633, -2.03444394, -2.35619449],
               [-0.46364761, -0.78539816, -1.57079633, -2.35619449, -2.67794504],
               [ 0.        ,  0.        , -3.14159265, -3.14159265, -3.14159265],
@@ -264,7 +264,7 @@ def T(x: X, y: Y, *, t0=0):
     definitions are also available to control the output::
 
        >>> t = T(x0=-2, y0=-2, scale=2)
-       >>> t(5,5)
+       >>> t(width=5, height=5)
        array([[1.57079633, 1.32581766, 1.10714872, 0.92729522, 0.78539816],
               [1.57079633, 1.24904577, 0.98279372, 0.78539816, 0.64350111],
               [1.57079633, 1.10714872, 0.78539816, 0.5880026 , 0.46364761],

--- a/arlunio/lib/parameters.py
+++ b/arlunio/lib/parameters.py
@@ -3,7 +3,7 @@ import numpy as np
 
 
 @ar.definition
-def X(width, height, *, x0=0, scale=1, stretch=False):
+def X(width: int, height: int, *, x0=0, scale=1, stretch=False):
     """
     .. arlunio-image::
 
@@ -78,7 +78,7 @@ def X(width, height, *, x0=0, scale=1, stretch=False):
 
 
 @ar.definition
-def Y(width, height, *, y0=0, scale=1, stretch=False):
+def Y(width: int, height: int, *, y0=0, scale=1, stretch=False):
     """
     .. arlunio-image::
 

--- a/arlunio/lib/pattern.py
+++ b/arlunio/lib/pattern.py
@@ -15,7 +15,7 @@ def Grid(width: int, height: int, *, n=4, m=None, defn=None) -> ar.Mask:
        from arlunio.lib import Circle, Grid
 
        pattern = Grid(defn=Circle())
-       image = ar.fill(pattern(1920, 1080))
+       image = ar.fill(pattern(width=1920, height=1080))
 
     Repeatedly draw the given defintition in a grid.
 
@@ -57,7 +57,9 @@ def Grid(width: int, height: int, *, n=4, m=None, defn=None) -> ar.Mask:
            return c(x=np.abs(x), y=np.abs(y))
 
        pattern = Grid(defn=Template(scale=1.))
-       image = ar.fill(pattern(1080,1080), background="#000", color="#ff0")
+       image = ar.fill(
+           pattern(width=1080, height=1080), background="#000", color="#ff0"
+       )
 
     A checkerboard like pattern
 
@@ -74,7 +76,7 @@ def Grid(width: int, height: int, *, n=4, m=None, defn=None) -> ar.Mask:
            return np.abs(x) - np.abs(y) < 0
 
        grid = Grid(defn=Template(), n=22, m=13)
-       image = ar.fill(grid(1920, 1080))
+       image = ar.fill(grid(width=1920, height=1080))
     """
     if m is None:
         m = n
@@ -83,7 +85,7 @@ def Grid(width: int, height: int, *, n=4, m=None, defn=None) -> ar.Mask:
 
     # Draw the shape at a size determined by the size of the grid
     s_height, s_width = height // m, width // n
-    mask = defn(s_width, s_height)
+    mask = defn(width=s_width, height=s_height)
 
     # Let numpy handle the repeating of the shape across the image.
     pattern = np.tile(mask, (m, n))
@@ -126,7 +128,7 @@ def Map(width: int, height: int, *, layout=None, legend=None) -> ar.Mask:
        from arlunio.lib import Empty, Map, Rectangle
 
        @ar.definition
-       def Wall(width, height, *, sides=None):
+       def Wall(width: int, height: int, *, sides=None):
            r = 50
            d = 1
            walls = {
@@ -139,7 +141,7 @@ def Map(width: int, height: int, *, layout=None, legend=None) -> ar.Mask:
            mask = False
            for side in sides.split('-'):
                wall = Rectangle(size=0.2, **walls[side])
-               mask = ar.any(mask, wall(width, height))
+               mask = ar.any(mask, wall(width=width, height=height))
 
            return mask
 
@@ -164,15 +166,16 @@ def Map(width: int, height: int, *, layout=None, legend=None) -> ar.Mask:
        ])
 
        map_ = Map(legend=legend, layout=layout)
-       image = ar.fill(map_(1080, 1080), color="blue")
+       image = ar.fill(map_(width=1080, height=1080), color="blue")
     """
 
+    # TODO: Handle divisions with rounding errors
     nx, ny = len(layout), len(layout[0])
-    size = (height // ny, width // nx)  # TODO: Handle divisions with rounding errors
+    size = {"height": height // ny, "width": width // nx}
 
     # Build a new dict with the values being the shapes drawn at the appropriate res
     # to ensure we only draw them once.
-    items = {k: v(*size) for k, v in legend.items()}
+    items = {k: v(**size) for k, v in legend.items()}
     return np.block([[items[key] for key in row] for row in layout])
 
 
@@ -187,7 +190,7 @@ def Pixelize(
        from arlunio.lib import Circle, Pixelize
 
        pix = Pixelize(defn=Circle(), n=32, m=32)
-       image = ar.fill(pix(1920, 1080))
+       image = ar.fill(pix(width=1920, height=1080))
 
     Draw a pixelated version of a definition.
 
@@ -237,7 +240,7 @@ def Pixelize(
            [False,  True,  True, False]
        ])
        defn = Pixelize(pixels=pixels)
-       image = ar.fill(defn(1080, 1080))
+       image = ar.fill(defn(width=1080, height=1080))
 
     Alternatively we can generate the pixels from an instance of another definition
 
@@ -269,7 +272,7 @@ def Pixelize(
            )
 
        ghost = Pixelize(defn=Ghost(y0=-0.3), n=32, m=32)
-       image = ar.fill(ghost(1080,1080), color="#f00")
+       image = ar.fill(ghost(width=1080, height=1080), color="#f00")
     """
 
     if defn is None and pixels is None:
@@ -280,7 +283,7 @@ def Pixelize(
         if n is None or m is None:
             raise ValueError("You must also provide the `n` and `m` attributes")
 
-        pixels = defn(n, m)
+        pixels = defn(width=n, height=m)
 
     n, m = len(pixels), len(pixels[0])
     size = (height // m, width // n)  # TODO: Handle divisions with rounding errors

--- a/arlunio/lib/pattern.py
+++ b/arlunio/lib/pattern.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 @ar.definition
-def Grid(width, height, *, n=4, m=None, defn=None) -> ar.Mask:
+def Grid(width: int, height: int, *, n=4, m=None, defn=None) -> ar.Mask:
     """
     .. arlunio-image::
 
@@ -99,7 +99,7 @@ def Grid(width, height, *, n=4, m=None, defn=None) -> ar.Mask:
 
 
 @ar.definition
-def Map(width, height, *, layout=None, legend=None) -> ar.Mask:
+def Map(width: int, height: int, *, layout=None, legend=None) -> ar.Mask:
     """For more complex layouts.
 
     .. note::
@@ -177,7 +177,9 @@ def Map(width, height, *, layout=None, legend=None) -> ar.Mask:
 
 
 @ar.definition
-def Pixelize(width, height, *, pixels=None, defn=None, n=None, m=None) -> ar.Mask:
+def Pixelize(
+    width: int, height: int, *, pixels=None, defn=None, n=None, m=None
+) -> ar.Mask:
     """
     .. arlunio-image::
 

--- a/arlunio/lib/shapes.py
+++ b/arlunio/lib/shapes.py
@@ -13,7 +13,7 @@ def Circle(x: X, y: Y, *, xc=0, yc=0, r=0.8, pt=None) -> ar.Mask:
         from arlunio.lib import Circle
 
         circle = Circle()
-        image = ar.fill(circle(1920, 1080))
+        image = ar.fill(circle(width=1920, height=1080))
 
     We define a circle using the following equality.
 
@@ -49,7 +49,7 @@ def Circle(x: X, y: Y, *, xc=0, yc=0, r=0.8, pt=None) -> ar.Mask:
        from arlunio.lib import Circle
 
        @ar.definition
-       def Target(width, height):
+       def Target(width: int, height: int):
            image = None
            parts = [
                (Circle(pt=0.02), "#000"),
@@ -59,12 +59,14 @@ def Circle(x: X, y: Y, *, xc=0, yc=0, r=0.8, pt=None) -> ar.Mask:
            ]
 
            for part, color in parts:
-               image = ar.fill(part(width, height), color=color, image=image)
+               image = ar.fill(
+                   part(width=width, height=height), color=color, image=image
+               )
 
            return image
 
        target = Target()
-       image = target(1920, 1080)
+       image = target(width=1920, height=1080)
 
     Making use of the :code:`xc` and :code:`yc` attributes we can produce an
     approximation of the olympics logo
@@ -76,7 +78,7 @@ def Circle(x: X, y: Y, *, xc=0, yc=0, r=0.8, pt=None) -> ar.Mask:
        from arlunio.lib import Circle
 
        @ar.definition
-       def OlympicRings(width, height, *, spacing=0.5, pt=0.025):
+       def OlympicRings(width: int, height: int, *, spacing=0.5, pt=0.025):
 
            dy = spacing / 4
            dx = spacing / 2
@@ -92,11 +94,14 @@ def Circle(x: X, y: Y, *, xc=0, yc=0, r=0.8, pt=None) -> ar.Mask:
            ]
 
            for ring, color in rings:
-               image = ar.fill(ring(width, height), color=color, image=image)
+               image = ar.fill(
+                   ring(width=width, height=height), color=color, image=image
+               )
+
            return image
 
        rings = OlympicRings()
-       image = rings(1920, 1080)
+       image = rings(width=1920, height=1080)
     """
     x = (x - xc) ** 2
     y = (y - yc) ** 2
@@ -120,7 +125,7 @@ def Ellipse(x: X, y: Y, *, xc=0, yc=0, a=2, b=1, r=0.8, pt=None) -> ar.Mask:
        from arlunio.lib import Ellipse
 
        ellipse = Ellipse()
-       image = ar.fill(ellipse(1920, 1080))
+       image = ar.fill(ellipse(width=1920, height=1080))
 
     An ellipse can be defined using the following equality.
 
@@ -169,7 +174,7 @@ def Ellipse(x: X, y: Y, *, xc=0, yc=0, a=2, b=1, r=0.8, pt=None) -> ar.Mask:
        from arlunio.lib import Ellipse
 
        @ar.definition
-       def EllipseDemo(width, height):
+       def EllipseDemo(width: int, height: int):
            image = None
            ellipses = [
                Ellipse(xc=-0.5, yc=-0.5, a=0.5, b=0.5, r=0.4),
@@ -182,11 +187,11 @@ def Ellipse(x: X, y: Y, *, xc=0, yc=0, a=2, b=1, r=0.8, pt=None) -> ar.Mask:
            ]
 
            for ellipse in ellipses:
-               image = ar.fill(ellipse(1920, 1080), image=image)
+               image = ar.fill(ellipse(width=1920, height=1080), image=image)
            return image
 
        demo = EllipseDemo()
-       image = demo(1920, 1080)
+       image = demo(width=1920, height=1080)
 
     Playing around with the values and the coordinate inputs it's possible to draw
     something that looks like a diagram of an atom
@@ -215,7 +220,7 @@ def Ellipse(x: X, y: Y, *, xc=0, yc=0, a=2, b=1, r=0.8, pt=None) -> ar.Mask:
            return image
 
        atom = Atom()
-       image = atom(1920, 1080)
+       image = atom(width=1920, height=1080)
     """
 
     x = (x - xc) ** 2
@@ -246,7 +251,7 @@ def SuperEllipse(
        from arlunio.lib import SuperEllipse
 
        ellipse = SuperEllipse()
-       image = ar.fill(ellipse(1920,1080))
+       image = ar.fill(ellipse(width=1920, height=1080))
 
     We define a `SuperEllipse`_ by the following equality.
 
@@ -256,10 +261,10 @@ def SuperEllipse(
 
     Attributes
     ----------
-    x_c:
+    xc:
         Corresponds with the :math:`x_c` variable in the equation above and defines the
         :math:`x`-coordinate of the center of the super ellipse.
-    y_c:
+    yc:
         Corresponds with the :math:`y_c` variable in the equation above and defines the
         :math:`y` -coordinate of the center of the super ellipse.
     r:
@@ -299,7 +304,7 @@ def SuperEllipse(
        from arlunio.lib import SuperEllipse
 
        @ar.definition
-       def SuperEllipseDemo(width, height):
+       def SuperEllipseDemo(width: int, height: int):
            image = None
            ellipses = [
                (SuperEllipse(n=0.5, pt=0.01),'#f00'),
@@ -310,12 +315,14 @@ def SuperEllipse(
            ]
 
            for ellipse, color in ellipses:
-               image = ar.fill(ellipse(1920, 1080), color=color, image=image)
+               image = ar.fill(
+                   ellipse(width=1920, height=1080), color=color, image=image
+               )
 
            return image
 
        demo = SuperEllipseDemo()
-       image = demo(1920, 1080)
+       image = demo(width=1920, height=1080)
 
     By default if you don't specify a value for :code:`m` it will inherit the value
     assigned to :code:`n`. However if you set :code:`m` to a different value then you
@@ -328,7 +335,7 @@ def SuperEllipse(
        from arlunio.lib import SuperEllipse
 
        @ar.definition
-       def Sauron(width, height):
+       def Sauron(width: int, height: int):
            image = None
            ellipses = [
                (SuperEllipse(a=2, n=3, m=0.2, r=0.98),'#f00'),
@@ -337,12 +344,14 @@ def SuperEllipse(
            ]
 
            for ellipse, color in ellipses:
-               image = ar.fill(ellipse(1920, 1080), color=color, image=image)
+               image = ar.fill(
+                   ellipse(width=1920, height=1080), color=color, image=image
+               )
 
            return image
 
        eye = Sauron()
-       image = eye(1920, 1080)
+       image = eye(width=1920, height=1080)
 
     .. _SuperEllipse: https://en.wikipedia.org/wiki/Superellipse
 
@@ -379,7 +388,7 @@ def Empty(width: int, height: int) -> ar.Mask:
        from arlunio.lib import Empty
 
        e = Empty()
-       image = ar.fill(e(1920, 1080))
+       image = ar.fill(e(width=1920, height=1080))
     """
     return np.full((height, width), False)
 
@@ -398,7 +407,7 @@ def Full(width: int, height: int) -> ar.Mask:
        from arlunio.lib import Full
 
        f = Full()
-       image = ar.fill(f(1920, 1080))
+       image = ar.fill(f(width=1920, height=1080))
     """
     return np.full((height, width), True)
 
@@ -412,7 +421,7 @@ def Square(x: X, y: Y, *, xc=0, yc=0, size=0.8, pt=None) -> ar.Mask:
        from arlunio.lib import Square
 
        square = Square()
-       image = ar.fill(square(1920, 1080))
+       image = ar.fill(square(width=1920, height=1080))
 
     A square.
 
@@ -456,7 +465,7 @@ def Square(x: X, y: Y, *, xc=0, yc=0, size=0.8, pt=None) -> ar.Mask:
            return image
 
        square = SquareDemo()
-       image = square(1920, 1080)
+       image = square(width=1920, height=1080)
     """
 
     xs = np.abs(x - xc)
@@ -483,7 +492,7 @@ def Rectangle(x: X, y: Y, *, xc=0, yc=0, size=0.6, ratio=1.618, pt=None) -> ar.M
        from arlunio.lib import Rectangle
 
        rectangle = Rectangle()
-       image = ar.fill(rectangle(1920, 1080))
+       image = ar.fill(rectangle(width=1920, height=1080))
 
     A Rectangle.
 
@@ -513,7 +522,7 @@ def Rectangle(x: X, y: Y, *, xc=0, yc=0, size=0.6, ratio=1.618, pt=None) -> ar.M
        from arlunio.lib import Rectangle
 
        @ar.definition
-       def RectangleDemo(width, height):
+       def RectangleDemo(width: int, height: int):
            image = None
            rects = [
                Rectangle(xc=-1, size=0.4, ratio=0.5),
@@ -522,12 +531,12 @@ def Rectangle(x: X, y: Y, *, xc=0, yc=0, size=0.6, ratio=1.618, pt=None) -> ar.M
            ]
 
            for r in rects:
-               image = ar.fill(r(width, height), image=image)
+               image = ar.fill(r(width=width, height=height), image=image)
 
            return image
 
        demo = RectangleDemo()
-       image = demo(1920, 1080)
+       image = demo(width=1920, height=1080)
     """
 
     xs = np.abs(x - xc)

--- a/arlunio/lib/shapes.py
+++ b/arlunio/lib/shapes.py
@@ -366,7 +366,7 @@ def SuperEllipse(
 
 
 @ar.definition
-def Empty(width, height) -> ar.Mask:
+def Empty(width: int, height: int) -> ar.Mask:
     """An empty shape definition.
 
     Example
@@ -385,7 +385,7 @@ def Empty(width, height) -> ar.Mask:
 
 
 @ar.definition
-def Full(width, height) -> ar.Mask:
+def Full(width: int, height: int) -> ar.Mask:
     """An full shape definition.
 
     Example

--- a/changes/216.feature.rst
+++ b/changes/216.feature.rst
@@ -1,0 +1,3 @@
+Generalise definitions to accept any "regular" value as an input, not just
+:code:`width` and :code:`height`. In a similar way to attributes, when deriving
+from other definitions any inputs will be automatically inherited.

--- a/changes/216.misc.rst
+++ b/changes/216.misc.rst
@@ -1,0 +1,1 @@
+Fix packaging so that our tests are no longer installed

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,6 +79,8 @@ autodoc_member_order = "groupwise"
 autodoc_default_options = {"members": True}
 # autodoc_typehints = "description" TODO: Try this when Sphinx 3.0 ships...
 
+linkcheck_ignore = ["https://crontab.guru/#"]
+
 intersphinx_mapping = {
     "pillow": ("https://pillow.readthedocs.io/en/stable/", None),
     "python": ("https://docs.python.org/3", None),

--- a/docs/users/getting-started/your-first-image.rst
+++ b/docs/users/getting-started/your-first-image.rst
@@ -12,7 +12,7 @@ code::
    from arlunio.lib import Circle
 
    circle = Circle()
-   ar.fill(circle(1920, 1080), color="red")
+   ar.fill(circle(width=1920, height=1080), color="red")
 
 .. only:: html
 
@@ -22,4 +22,4 @@ code::
       from arlunio.lib import Circle
 
       circle = Circle()
-      image = ar.fill(circle(1920, 1080), color="red")
+      image = ar.fill(circle(width=1920, height=1080), color="red")

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     author="Alex Carney",
     author_email="alcarneyme@gmail.com",
     license="MIT",
-    packages=find_packages(".", exclude=["tests"]),
+    packages=find_packages(".", exclude=["tests*"]),
     package_data={
         "arlunio.cli.scripts": ["*.sh"],
         "arlunio.tutorial": ["*.ipynb", "**/*.ipynb"],

--- a/tests/doc/test_directives.py
+++ b/tests/doc/test_directives.py
@@ -58,7 +58,7 @@ def test_render_image_image_provided():
     from arlunio.lib.shapes import Circle
 
     circle = Circle()
-    disk = ar.fill(circle(4,4))
+    disk = ar.fill(circle(width=4, height=4))
     """
     doctree = render_image(textwrap.dedent(src))
 

--- a/tests/lib/test_parameters.py
+++ b/tests/lib/test_parameters.py
@@ -12,7 +12,7 @@ def test_X_matches_dimension(width, height):
     """Ensure that the output shape matches the width and height of the image"""
 
     x = X()
-    assert x(width, height).shape == (height, width)
+    assert x(width=width, height=height).shape == (height, width)
 
 
 @given(width=T.dimension, height=T.dimension)
@@ -20,7 +20,7 @@ def test_X_uniform_vertically(width, height):
     """Ensure that the output only varies in the x-direction"""
 
     x = X()
-    xs = x(width, height)
+    xs = x(width=width, height=height)
 
     assert np.unique(xs, axis=0).shape == (1, width)
 
@@ -32,7 +32,7 @@ def test_X_adapts_to_image_ratio_by_default(width, height, scale):
     assume(width / height > 1)
 
     x = X(scale=scale)
-    xs = x(width, height)
+    xs = x(width=width, height=height)
 
     assert width / height == py.test.approx(np.max(xs) / scale)
 
@@ -43,7 +43,7 @@ def test_X_fits_to_image_size_when_told(width, height, scale):
     is set."""
 
     x = X(scale=scale, stretch=True)
-    xs = x(width, height)
+    xs = x(width=width, height=height)
 
     assert np.max(xs) == scale
 
@@ -56,8 +56,8 @@ def test_X_shifts_origin_accordingly(width, height, offset):
     x1 = X()
     x2 = X(x0=offset)
 
-    x1s = x1(width, height)
-    x2s = x2(width, height)
+    x1s = x1(width=width, height=height)
+    x2s = x2(width=width, height=height)
 
     npt.assert_almost_equal(x1s - x2s, offset)
 
@@ -67,7 +67,7 @@ def test_Y_matches_dimension(width, height):
     """Ensure that the output shape matches the width and height of the image."""
 
     y = Y()
-    ys = y(width, height)
+    ys = y(width=width, height=height)
 
     assert ys.shape == (height, width)
 
@@ -77,7 +77,7 @@ def test_Y_uniform_horizontally(width, height):
     """Ensure that the output only varies in the y direction"""
 
     y = Y()
-    ys = y(width, height)
+    ys = y(width=width, height=height)
 
     assert np.unique(ys, axis=1).shape == (height, 1)
 
@@ -89,7 +89,7 @@ def test_Y_adapts_to_image_ratio_by_default(width, height, scale):
     assume(height / width > 1)
 
     y = Y(scale=scale)
-    ys = y(width, height)
+    ys = y(width=width, height=height)
 
     assert height / width == py.test.approx(np.max(ys) / scale)
 
@@ -100,7 +100,7 @@ def test_Y_fits_to_image_size_when_told(width, height, scale):
     is set."""
 
     y = Y(scale=scale, stretch=True)
-    ys = y(width, height)
+    ys = y(width=width, height=height)
 
     assert np.max(ys) == scale
 
@@ -113,7 +113,7 @@ def test_Y_shifts_origin_accordingly(width, height, offset):
     y1 = Y()
     y2 = Y(y0=offset)
 
-    y1s = y1(width, height)
-    y2s = y2(width, height)
+    y1s = y1(width=width, height=height)
+    y2s = y2(width=width, height=height)
 
     npt.assert_almost_equal(y1s - y2s, offset)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,9 +1,9 @@
-import inspect
-
 from typing import Any
 
 import arlunio as ar
 import py.test
+
+from arlunio import DefnInput
 
 
 def test_definition_name():
@@ -11,7 +11,7 @@ def test_definition_name():
 
     @ar.definition
     def Circle():
-        return 1
+        pass
 
     assert Circle.__name__ == "Circle"
 
@@ -27,73 +27,69 @@ def test_definition_module():
     assert Circle.__module__ == "tests.test_core"
 
 
-def test_use_definition_as_tag():
-    """Ensure that the definition decorator can be used as a simple tag."""
-
-    @ar.definition
-    def z123_(width, height):
-        return width
-
-    p = z123_()
-    assert p(4, 2) == 4
-
-
-def test_use_definition_as_function():
-    """Ensure that the definition decorator can be used as a function."""
-
-    @ar.definition()
-    def Param(width, height):
-        return height
-
-    p = Param()
-    assert p(4, 2) == 2
-
-
 def test_definition_constant():
-    """Ensure that we can define as constant definition."""
+    """Ensure that we can define a constant definition."""
 
     @ar.definition()
     def Constant():
         return 1
 
     const = Constant()
-    assert const(10, 10) == 1
+    assert const() == 1
 
 
-def test_definition_width_only():
-    """Ensure that we can define a definition with respect to width only."""
+def test_definition_param_missing_annotation():
+    """Ensure that we require parameters to carry a type annotation"""
 
-    @ar.definition()
-    def Width(width):
-        return width + 1
+    with py.test.raises(TypeError) as err:
 
-    w = Width()
-    assert w(100, 2) == 101
+        @ar.definition()
+        def Width(width):
+            return width + 1
+
+    assert "Missing type annotation" in str(err.value)
+    assert "width" in str(err.value)
 
 
-def test_definition_height_only():
-    """Ensure that we can define a definition with respect to height only."""
+def test_definition_errors_with_pos_args():
+    """Ensure that if a definition is called with positional args a helpful
+    error message is thrown."""
 
-    @ar.definition()
-    def Height(height):
+    @ar.definition
+    def Height(height: int):
+        return height
+
+    h = Height()
+
+    with py.test.raises(TypeError) as err:
+        h(12)
+
+    assert "must be passed as keyword arguments" in str(err.value)
+
+
+def test_definition_simple_param():
+    """Ensure that we can define a parameter that takes a simple parameter."""
+
+    @ar.definition
+    def Height(height: int):
         return height - 1
 
     h = Height()
-    assert h(2, 100) == 99
+    assert h(height=100) == 99
 
 
 def test_definition_attributes():
     """Ensure that we can define a definition that takes a number of attributes."""
 
     @ar.definition()
-    def Param(width, height, *, offset=0):
-        return (width + height) - offset
+    def Param(*, offset=0):
+        return 2 - offset
 
     p = Param()
-    assert p(1, 1) == 2
+    assert p() == 2
 
     q = Param(offset=2)
-    assert q(1, 1) == 0
+    assert q() == 0
 
 
 def test_definition_produces_any():
@@ -124,7 +120,7 @@ def test_derived_definition():
     """Ensure that we can derive a definition that's based on other definitions."""
 
     @ar.definition()
-    def Adder(width, height):
+    def Adder(width: int, height: int):
         return height + width
 
     @ar.definition()
@@ -132,34 +128,8 @@ def test_derived_definition():
         return a - 2
 
     s = Subber()
-    assert s(1, 1) == 0
-    assert s(1, 2) == 1
-
-
-def test_derived_definition_checks_input_annotations():
-    """Ensure that any inputs that are not a base definition or annotated are complained
-    about."""
-
-    with py.test.raises(TypeError) as err:
-
-        @ar.definition()
-        def Parameter(width, height, x):
-            return width * height - x
-
-    assert "Unknown input 'x'" in str(err.value)
-
-
-def test_derived_definition_checks_input_annotation_type():
-    """Ensure that any inputs that are annotated with a class that's not a Parameter are
-    compained about."""
-
-    with py.test.raises(TypeError) as err:
-
-        @ar.definition()
-        def Parameter(width, height, x: int):
-            return width * height - x
-
-    assert "Invalid input 'x', type 'int' is not a Defn" in str(err.value)
+    assert s(width=1, height=1) == 0
+    assert s(width=1, height=2) == 1
 
 
 def test_derived_definition_exposes_properties():
@@ -167,7 +137,7 @@ def test_derived_definition_exposes_properties():
     property."""
 
     @ar.definition()
-    def Base(width, height, *, offset=0):
+    def Base(width: int, height: int, *, offset=0):
         return offset
 
     @ar.definition()
@@ -175,29 +145,138 @@ def test_derived_definition_exposes_properties():
         return start - b
 
     d = Derived()
-    d(1, 1) == 1
+    d(width=1, height=1) == 1
 
     d = Derived(start=5, offset=-1)
-    d(1, 1) == 6
+    d(width=1, height=1) == 6
 
 
-def test_derived_definition_exposes_base_definitions():
-    """Ensure that any base definitions are available to be inspected."""
+@ar.definition
+def Const():
+    return 1
 
-    @ar.definition()
-    def Base(width, height):
-        return 2
 
-    assert Base.definitions == {
-        "width": inspect.Parameter.empty,
-        "height": inspect.Parameter.empty,
-    }
+@ar.definition
+def Base(width: int, height: int):
+    return 2
 
-    @ar.definition()
-    def Derived(width, base: Base):
-        return 4
 
-    assert Derived.definitions == {"width": inspect.Parameter.empty, "base": Base}
+@ar.definition
+def Cuboid(width: int, color: str, base: Base):
+    return 3
+
+
+@ar.definition()
+def Tunnel(base: Base, length: int):
+    return 4
+
+
+class TestDefinitionBases:
+    """Tests relating to definition bases."""
+
+    @py.test.mark.parametrize("defn,expected", [(Base, {}), (Tunnel, {"base": Base})])
+    def test_bases_classmethod(self, defn, expected):
+        """Ensure that any bases a definition is derived from is exposed."""
+
+        assert defn.bases() == expected
+        assert defn().bases() == expected
+
+
+class TestDefinitionInputs:
+    """Tests relating to definition inputs."""
+
+    def test_inputs_classmethod_constant_defn(self):
+        """Defns that don't define any inputs should return an empty dict."""
+
+        assert Const.inputs() == {}
+        assert Const().inputs() == {}
+
+    def test_inputs_classmethod_simple_defn(self):
+        """Ensure that all explicitly defined definitions are reported."""
+
+        expected = {
+            "width": DefnInput(name="width", dtype=int, inherited=False),
+            "height": DefnInput(name="height", dtype=int, inherited=False),
+        }
+
+        assert Base.inputs() == expected
+        assert Base().inputs() == expected
+
+    def test_inputs_classmethod_simple_derived(self):
+        """Any inputs from base definitions should also be exposed by default, but
+        marked as being inherited."""
+
+        expected = {
+            "length": DefnInput(name="length", dtype=int, inherited=False),
+            "width": DefnInput(name="width", dtype=int, inherited=True, sources=[Base]),
+            "height": DefnInput(
+                name="height", dtype=int, inherited=True, sources=[Base]
+            ),
+        }
+
+        assert Tunnel.inputs() == expected
+        assert Tunnel().inputs() == expected
+
+    def test_inputs_classmethod_simple_derived_inhertited_false(self):
+        """Ensure that we can ask only for the inputs that have been directly declared
+        on the definition."""
+
+        expected = {"length": DefnInput(name="length", dtype=int, inherited=False)}
+
+        assert Tunnel.inputs(inherited=False) == expected
+        assert Tunnel().inputs(inherited=False) == expected
+
+    def test_inputs_classmethod_shadowed_inputs(self):
+        """Ensure that any inputs that are both explicitly declared and carried on a
+        base definition are marked as not being inherited."""
+
+        expected = {
+            "width": DefnInput(name="width", dtype=int, inherited=False),
+            "color": DefnInput(name="color", dtype=str, inherited=False),
+            "height": DefnInput(
+                name="height", dtype=int, inherited=True, sources=[Base]
+            ),
+        }
+
+        assert Cuboid.inputs() == expected
+        assert Cuboid().inputs() == expected
+
+    def test_inputs_classmethod_shadowed_inputs_many_sources(self):
+        """Ensure that any inputs inherited from multiple sources are captured as
+        such."""
+
+        @ar.definition
+        def ADefn(b: Base, c: Cuboid):
+            pass
+
+        expected = {
+            "width": DefnInput(
+                name="width", dtype=int, inherited=True, sources=[Base, Cuboid]
+            ),
+            "height": DefnInput(
+                name="height", dtype=int, inherited=True, sources=[Base, Cuboid]
+            ),
+            "color": DefnInput(
+                name="color", dtype=str, inherited=True, sources=[Cuboid]
+            ),
+        }
+
+        assert ADefn.inputs() == expected
+        assert ADefn().inputs() == expected
+
+    def test_report_conflicting_inputs(self):
+        """Ensure that if a definition declares an input that conflicts with an
+        inherited one an appropriate error is raised."""
+
+        with py.test.raises(TypeError) as err:
+
+            @ar.definition
+            def BadDefinition(width: str, base: Base):
+                pass
+
+        assert "conflicts with" in str(err.value)
+        assert "'width'" in str(err.value)
+        assert "'Base'" in str(err.value)
 
 
 def test_derived_definition_attributes_inherited():
@@ -205,7 +284,7 @@ def test_derived_definition_attributes_inherited():
     attributes on the definition."""
 
     @ar.definition
-    def Base(width, height, *, a=1, b=2):
+    def Base(width: int, height: int, *, a=1, b=2):
         return 3
 
     assert Base().attributes(inherited=True) == {"a": 1, "b": 2}
@@ -222,7 +301,7 @@ def test_derived_definition_attributes():
     defined on the definition by default."""
 
     @ar.definition
-    def Base(width, height, *, a=1, b=2):
+    def Base(width: int, height: int, *, a=1, b=2):
         return 3
 
     assert Base().attributes() == {"a": 1, "b": 2}
@@ -239,7 +318,7 @@ def test_derived_definiton_attribs_inherited():
     attribute definitions."""
 
     @ar.definition
-    def Base(width, height, *, a=1, b=2):
+    def Base(width: int, height: int, *, a=1, b=2):
         return 3
 
     attrs = Base.attribs(inherited=True)
@@ -264,7 +343,7 @@ def test_derived_definiton_attribs():
     attribute definitions."""
 
     @ar.definition
-    def Base(width, height, *, a=1, b=2):
+    def Base(width: int, height: int, *, a=1, b=2):
         return 3
 
     attrs = Base.attribs()
@@ -284,35 +363,18 @@ def test_derived_definiton_attribs():
         assert name == attr.name
 
 
-def test_derived_definition_eval_width_height():
-    """Ensure that a definition can be evaluated with width and height as positional
-    arguments."""
-
-    @ar.definition()
-    def Base(width, height):
-        return width + height
-
-    assert Base()(4, 4) == 8
-
-    @ar.definition()
-    def Derived(height, base: Base):
-        return height - base
-
-    assert Derived()(2, 4) == -2
-
-
 def test_derived_definition_eval_kwargs():
     """Ensure that a definition can be evaluted with inputs provided as keyword
     arguments"""
 
     @ar.definition()
-    def Base(width, height):
+    def Base(width: int, height: int):
         return width + height
 
     assert Base()(width=4, height=4) == 8
 
     @ar.definition()
-    def Derived(height, base: Base):
+    def Derived(height: int, base: Base):
         return height - base
 
     assert Derived()(height=4, base=4) == 0
@@ -365,7 +427,7 @@ def test_definition_operator_missing_attributes():
     with py.test.raises(TypeError) as err:
 
         @ar.definition(operation="op")
-        def Op(width, height):
+        def Op(width: int, height: int):
             pass
 
     assert "must define 2 attributes" in str(err.value)
@@ -379,7 +441,7 @@ def test_definition_operator_missing_annotation():
     with py.test.raises(TypeError) as err:
 
         @ar.definition(operation="op")
-        def OpA(width, height, *, a=1, b: int = 2):
+        def OpA(width: int, height: int, *, a=1, b: int = 2):
             pass
 
     assert "missing a valid type annotation" in str(err.value)
@@ -388,7 +450,7 @@ def test_definition_operator_missing_annotation():
     with py.test.raises(TypeError) as err:
 
         @ar.definition(operation="op")
-        def OpB(width, height, *, a: int = 1, b=2):
+        def OpB(width: int, height: int, *, a: int = 1, b=2):
             pass
 
     assert "missing a valid type annotation" in str(err.value)
@@ -402,13 +464,13 @@ def test_definition_operator_existing_definition():
     operator_pool = {}
 
     @ar.definition(operation="op", operator_pool=operator_pool)
-    def Op(width, height, *, a: int = 0, b: int = 0):
+    def Op(width: int, height: int, *, a: int = 0, b: int = 0):
         pass
 
     with py.test.raises(TypeError) as err:
 
         @ar.definition(operation="op", operator_pool=operator_pool)
-        def OpDuplicate(width, height, *, a: int = 0, b: int = 0):
+        def OpDuplicate(width: int, height: int, *, a: int = 0, b: int = 0):
             pass
 
     assert "has already been defined" in str(err.value)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -278,6 +278,24 @@ class TestDefinitionInputs:
         assert "'width'" in str(err.value)
         assert "'Base'" in str(err.value)
 
+    def test_report_conflicting_bases(self):
+        """Ensure that if a definition includes bases that have conflicting inputs
+        an appropriate error is raised."""
+
+        @ar.definition
+        def Other(width: str):
+            pass
+
+        with py.test.raises(TypeError) as err:
+
+            @ar.definition
+            def Derived(b: Base, o: Other):
+                pass
+
+        assert "conflicts with" in str(err.value)
+        assert "'width'" in str(err.value)
+        assert "'Base'" in str(err.value)
+
 
 def test_derived_definition_attributes_inherited():
     """Ensure that the attributes method with the inherited flag exposes all available


### PR DESCRIPTION
Definitions are longer hard coded to accept `width` and `height` as inputs, in fact it should now be possible to create definitions that accept anything as an input! The change is *mostly* transparent although

- All **positional** arguments now require type annotations.
- When evaluating definitions all inputs must now be passed as keyword arguments

As with attributes, when deriving from an existing definition any inputs on the base definition(s) will automatically inherited. Since all inputs are now explicitly typed we can ensure that definitions don't define inputs that conflict with any implicit inputs inherited from their bases.

Closes #206 