### PR TITLE
Tweak how images are produced for the gallery

### DIFF
--- a/blog/src/gallery/Checkerboard.ipynb
+++ b/blog/src/gallery/Checkerboard.ipynb
@@ -7,7 +7,6 @@
    "outputs": [],
    "source": [
     "import arlunio as ar\n",
-    "\n",
     "from arlunio.lib import Grid, X, Y"
    ]
   },
@@ -31,9 +30,18 @@
     "@ar.definition\n",
     "def Checkerboard(width: int, height: int) -> ar.Image:\n",
     "    board = Grid(defn=CheckerPattern())\n",
-    "    return ar.fill(board(width=width, height=height))\n",
-    "\n",
-    "checkerboard = Checkerboard()"
+    "    return ar.fill(board(width=width, height=height))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "checkerboard = Checkerboard()\n",
+    "image = checkerboard(width=1080, height=1080) \n",
+    "image"
    ]
   }
  ],
@@ -42,10 +50,6 @@
    "author": {
     "github": "alcarney",
     "name": "Alex Carney"
-   },
-   "inputs": {
-    "height": 1080,
-    "width": 1080
    },
    "version": "0.0.6"
   },

--- a/blog/src/gallery/Rolling Hills.ipynb
+++ b/blog/src/gallery/Rolling Hills.ipynb
@@ -62,9 +62,18 @@
     "    image = ar.fill(big_hill(width=width, height=height), color=\"#0c0\", image=image)\n",
     "    image = ar.fill(small_hill(width=width, height=height), color=\"#0e0\", image=image)       \n",
     "\n",
-    "    return image \n",
-    "\n",
-    "image = RollingHills()"
+    "    return image "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hills = RollingHills()\n",
+    "image = hills(width=1920, height=1080)\n",
+    "image"
    ]
   }
  ],
@@ -73,10 +82,6 @@
    "author": {
     "github": "alcarney",
     "name": "Alex Carney"
-   },
-   "inputs": {
-    "height": 1080,
-    "width": 1920
    },
    "version": "0.0.6"
   },

--- a/blog/src/gallery/Simple Clock.ipynb
+++ b/blog/src/gallery/Simple Clock.ipynb
@@ -229,9 +229,18 @@
     "    minute_hand = ClockHand(size=0.02, length=0.8, scale=scale)\n",
     "    second_hand = ClockHand(size=0.01, length=.95, scale=scale)\n",
     "\n",
-    "    return make_clock(datetime.now(), width, height, image, hour_hand, minute_hand, second_hand)\n",
-    "\n",
-    "clock = Clock()"
+    "    return make_clock(datetime.now(), width, height, image, hour_hand, minute_hand, second_hand)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clock = Clock()\n",
+    "image = clock(width=1920, height=1080)\n",
+    "image"
    ]
   }
  ],
@@ -240,10 +249,6 @@
    "author": {
     "github": "alcarney",
     "name": "Alex Carney"
-   },
-   "inputs": {
-    "height": 1080,
-    "width": 1920
    },
    "version": "0.0.6"
   },

--- a/blog/templates/image.html
+++ b/blog/templates/image.html
@@ -39,10 +39,6 @@
             <i class="fas fa-history"></i><span>{{ revision }} revisions</span>
             <i class="far fa-file-code"></i><span>{{ sloc }} sloc</span>
             <i class="fas fa-terminal"></i><span>v{{ version }}</span>
-            {%- for key, value in inputs.items() -%}
-                <i class="far fa-image"></i>
-                <span>{{ key }}: {{ value }}</span>
-            {%- endfor -%}
         </div>
         <div class="image-meta">
             <label for="hide-notes">Notes</label>


### PR DESCRIPTION
Images should now be explicitly produced as part of the notebook, this should make the experience better for anyone who tries the binder version of the notebook. It should also simplify the contribution
process for new images.