### PR TITLE
Ensure compatibility with PEP 563

### DIFF
--- a/.github/workflows/python-pr.yml
+++ b/.github/workflows/python-pr.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         os: [ubuntu-latest]  # TODO: Enable windows-latest, macOS-latest
   # </test-job>
 

--- a/.vscode/arlunio.code-snippets
+++ b/.vscode/arlunio.code-snippets
@@ -1,0 +1,27 @@
+{
+    // Place your arlunio workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and
+    // description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope
+    // is left empty or omitted, the snippet gets applied to all languages. The prefix is what is
+    // used to trigger the snippet and the body will be expanded and inserted. Possible variables are:
+    // $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders.
+    // Placeholders with the same ids are connected.
+    // Example:
+    // "Print to console": {
+    // 	"scope": "javascript,typescript",
+    // 	"prefix": "log",
+    // 	"body": [
+    // 		"console.log('$1');",
+    // 		"$2"
+    // 	],
+    // 	"description": "Log output to console"
+    // }
+    "Future imports": {
+        "scope": "python",
+        "prefix": "_future",
+        "body": [
+            "from __future__ import annotations",
+            "$0"
+        ],
+        "description": "Insert from __future__ imports..."
+    },
+}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 **Arlunio is in early development, no guarantees we won't break something.**
 
 Inspired by ideas in mathematics Arlunio is library that aims to make drawing
-and animating with code not only possible but easy and fun! 
+and animating with code not only possible but easy and fun!
 
 <p align="center">
   <a href="https://www.arlun.io/gallery/">
@@ -29,7 +29,7 @@ Be sure to check out more examples in our [gallery](https://www.arlun.io/gallery
 
 ## Getting Started
 
-Arlunio is available for Python 3.6+ and can be installed using `pip`. It comes
+Arlunio is available for Python 3.7+ and can be installed using `pip`. It comes
 with an interactive tutorial based on Jupyter Notebooks:
 
 ```sh

--- a/arlunio/cli/__init__.py
+++ b/arlunio/cli/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import collections
 import logging

--- a/arlunio/cli/_interface.py
+++ b/arlunio/cli/_interface.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import inspect
 import logging

--- a/arlunio/cli/repl.py
+++ b/arlunio/cli/repl.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import subprocess
 import sys

--- a/arlunio/cli/tutorial.py
+++ b/arlunio/cli/tutorial.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import pathlib
 import shutil

--- a/arlunio/color.py
+++ b/arlunio/color.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import PIL.ImageColor as Color
 
 

--- a/arlunio/doc/__init__.py
+++ b/arlunio/doc/__init__.py
@@ -44,10 +44,10 @@ def _document_bases(defn: arlunio.Defn, lines: List[str]):
 
     defns = []
 
-    for name, value in defn.bases().items():
+    for name, base in defn.bases().items():
 
-        name = value.__name__
-        mod = value.__module__
+        name = base.defn.__name__
+        mod = base.defn.__module__
 
         defns.append(f":class:`{name} <{mod}.{name}>`")
 

--- a/arlunio/doc/__init__.py
+++ b/arlunio/doc/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 import textwrap
 from typing import Any

--- a/arlunio/doc/image.py
+++ b/arlunio/doc/image.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 import textwrap
 import traceback

--- a/arlunio/doc/notebook.py
+++ b/arlunio/doc/notebook.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import pathlib
 import re

--- a/arlunio/image.py
+++ b/arlunio/image.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import io
 import logging

--- a/arlunio/imp.py
+++ b/arlunio/imp.py
@@ -3,6 +3,8 @@ files. Currently includes support for the following formats.
 
 - :code:`.ipynb`: Jupyter Notebooks
 """
+from __future__ import annotations
+
 import importlib.util as imutil
 import logging
 import os

--- a/arlunio/mask.py
+++ b/arlunio/mask.py
@@ -112,7 +112,7 @@ def Full(width: int, height: int) -> Mask:
 
 @ar.definition(operation=ar.Defn.OP_ADD)
 def MaskAdd(
-    width: int, height: int, *, a: ar.Defn[Mask] = None, b: ar.Defn[Mask] = None
+    width: int, height: int, *, a: ar.Defn[Mask] = Empty(), b: ar.Defn[Mask] = Empty()
 ) -> Mask:
     """Add any two mask producing definitions together.
 
@@ -132,7 +132,7 @@ def MaskAdd(
 
 @ar.definition(operation=ar.Defn.OP_SUB)
 def MaskSub(
-    width: int, height: int, *, a: ar.Defn[Mask] = None, b: ar.Defn[Mask] = None
+    width: int, height: int, *, a: ar.Defn[Mask] = Full(), b: ar.Defn[Mask] = Empty()
 ) -> Mask:
     """Subtract one mask away from another mask.
 
@@ -156,7 +156,7 @@ def MaskSub(
 
 @ar.definition(operation=ar.Defn.OP_MUL)
 def MaskMul(
-    width: int, height: int, *, a: ar.Defn[Mask] = None, b: ar.Defn[Mask] = None
+    width: int, height: int, *, a: ar.Defn[Mask] = Full(), b: ar.Defn[Mask] = Full()
 ) -> Mask:
     """Muliply any two mask producing definitions together.
 

--- a/arlunio/mask.py
+++ b/arlunio/mask.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import logging
 from typing import Union

--- a/arlunio/math.py
+++ b/arlunio/math.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable
 
 import numpy as np

--- a/arlunio/pattern.py
+++ b/arlunio/pattern.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import arlunio as ar
 import arlunio.mask as mask
 import arlunio.math as math

--- a/arlunio/raytrace/camera.py
+++ b/arlunio/raytrace/camera.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import numpy.random as npr
 

--- a/arlunio/raytrace/data.py
+++ b/arlunio/raytrace/data.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import ClassVar
 
 import attr

--- a/arlunio/raytrace/material.py
+++ b/arlunio/raytrace/material.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import numpy.random as npr
 

--- a/arlunio/raytrace/object.py
+++ b/arlunio/raytrace/object.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 import numpy as np

--- a/arlunio/raytrace/render.py
+++ b/arlunio/raytrace/render.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 import numpy as np

--- a/arlunio/shape.py
+++ b/arlunio/shape.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 import arlunio as ar

--- a/arlunio/testing.py
+++ b/arlunio/testing.py
@@ -1,4 +1,6 @@
 """Helpers and utilities for writing tests."""
+from __future__ import annotations
+
 import hypothesis.strategies as st
 import numpy as np
 from hypothesis.extra import numpy

--- a/changes/252.fix.rst
+++ b/changes/252.fix.rst
@@ -1,0 +1,1 @@
+Ensure that we are future compatible with Python 3.9 by adhereing to :pep:`563`

--- a/changes/252.removal.rst
+++ b/changes/252.removal.rst
@@ -1,0 +1,1 @@
+Removed Python 3.6 support.

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     license="MIT",
     packages=find_packages(".", exclude=["tests*"]),
     include_package_data=True,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=required,
     extras_require=extras,
     classifiers=[
@@ -64,7 +64,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",

--- a/tests/test_definition.py
+++ b/tests/test_definition.py
@@ -26,18 +26,28 @@ def Tunnel(base: Base, length: int):
     return 4
 
 
+@ar.definition()
+def Circle(width: int, height: int, *, radius=0.5):
+    return radius
+
+
 class TestDefinition:
     """Tests around the basic properties of a definition"""
 
-    def test_name(self):
+    @py.test.mark.parametrize(
+        "defn,name",
+        [
+            (Base, "Base"),
+            (Circle, "Circle"),
+            (Const, "Const"),
+            (Cuboid, "Cuboid"),
+            (Tunnel, "Tunnel"),
+        ],
+    )
+    def test_name(self, defn, name):
         """Ensure that the returned definition keeps the name of the decorated
         function."""
-
-        @ar.definition
-        def Circle():
-            pass
-
-        assert Circle.__name__ == "Circle"
+        assert defn.__name__ == name
 
     def test_module(self):
         """Ensure that the returned definition reports its module as the one it was

--- a/tests/test_definition.py
+++ b/tests/test_definition.py
@@ -6,151 +6,6 @@ import arlunio as ar
 from arlunio import DefnInput
 
 
-def test_definition_name():
-    """Ensure that the returned definition keeps the name of the decorated function."""
-
-    @ar.definition
-    def Circle():
-        pass
-
-    assert Circle.__name__ == "Circle"
-
-
-def test_definition_module():
-    """Ensure that the returned definition reports its module as the one it was defined
-    in"""
-
-    @ar.definition()
-    def Circle():
-        pass
-
-    assert Circle.__module__ == "tests.test_definition"
-
-
-def test_definition_constant():
-    """Ensure that we can define a constant definition."""
-
-    @ar.definition()
-    def Constant():
-        return 1
-
-    const = Constant()
-    assert const() == 1
-
-
-def test_definition_param_missing_annotation():
-    """Ensure that we require parameters to carry a type annotation"""
-
-    with py.test.raises(TypeError) as err:
-
-        @ar.definition()
-        def Width(width):
-            return width + 1
-
-    assert "Missing type annotation" in str(err.value)
-    assert "width" in str(err.value)
-
-
-def test_definition_errors_with_pos_args():
-    """Ensure that if a definition is called with positional args a helpful
-    error message is thrown."""
-
-    @ar.definition
-    def Height(height: int):
-        return height
-
-    h = Height()
-
-    with py.test.raises(TypeError) as err:
-        h(12)
-
-    assert "must be passed as keyword arguments" in str(err.value)
-
-
-def test_definition_simple_param():
-    """Ensure that we can define a parameter that takes a simple parameter."""
-
-    @ar.definition
-    def Height(height: int):
-        return height - 1
-
-    h = Height()
-    assert h(height=100) == 99
-
-
-def test_definition_attributes():
-    """Ensure that we can define a definition that takes a number of attributes."""
-
-    @ar.definition()
-    def Param(*, offset=0):
-        return 2 - offset
-
-    p = Param()
-    assert p() == 2
-
-    q = Param(offset=2)
-    assert q() == 0
-
-
-def test_definition_produces_any():
-    """Ensure that a definition without a return annotation reports its return type as
-    :code:`Any`"""
-
-    @ar.definition()
-    def Param():
-        pass
-
-    assert Param.produces() == Any
-    assert Param().produces() == Any
-
-
-def test_definition_produces():
-    """Ensure that a definition reports what type it returns as declared by its return
-    annotation"""
-
-    @ar.definition()
-    def Param() -> int:
-        return 1
-
-    assert Param.produces() == int
-    assert Param().produces() == int
-
-
-def test_derived_definition():
-    """Ensure that we can derive a definition that's based on other definitions."""
-
-    @ar.definition()
-    def Adder(width: int, height: int):
-        return height + width
-
-    @ar.definition()
-    def Subber(a: Adder):
-        return a - 2
-
-    s = Subber()
-    assert s(width=1, height=1) == 0
-    assert s(width=1, height=2) == 1
-
-
-def test_derived_definition_exposes_properties():
-    """Ensure that any properties on base definitions are exposed on the derived
-    property."""
-
-    @ar.definition()
-    def Base(width: int, height: int, *, offset=0):
-        return offset
-
-    @ar.definition()
-    def Derived(b: Base, *, start=1):
-        return start - b
-
-    d = Derived()
-    d(width=1, height=1) == 1
-
-    d = Derived(start=5, offset=-1)
-    d(width=1, height=1) == 6
-
-
 @ar.definition
 def Const():
     return 1
@@ -171,27 +26,122 @@ def Tunnel(base: Base, length: int):
     return 4
 
 
-class TestDefinitionBases:
-    """Tests relating to definition bases."""
+class TestDefinition:
+    """Tests around the basic properties of a definition"""
 
-    @py.test.mark.parametrize("defn,expected", [(Base, {}), (Tunnel, {"base": Base})])
-    def test_bases_classmethod(self, defn, expected):
-        """Ensure that any bases a definition is derived from is exposed."""
+    def test_name(self):
+        """Ensure that the returned definition keeps the name of the decorated
+        function."""
 
-        assert defn.bases() == expected
-        assert defn().bases() == expected
+        @ar.definition
+        def Circle():
+            pass
+
+        assert Circle.__name__ == "Circle"
+
+    def test_module(self):
+        """Ensure that the returned definition reports its module as the one it was
+        defined in."""
+
+        @ar.definition()
+        def Circle():
+            pass
+
+        assert Circle.__module__ == "tests.test_definition"
+
+    def test_constant(self):
+        """Ensure that we can define a constant definition."""
+
+        @ar.definition()
+        def Constant():
+            return 1
+
+        const = Constant()
+        assert const() == 1
+
+    def test_param_missing_annotation(self):
+        """Ensure that we require parameters to carry a type annotation"""
+
+        with py.test.raises(TypeError) as err:
+
+            @ar.definition()
+            def Width(width):
+                return width + 1
+
+        assert "Missing type annotation" in str(err.value)
+        assert "width" in str(err.value)
+
+    def test_errors_with_pos_args(self):
+        """Ensure that if a definition is called with positional args a helpful
+        error message is thrown."""
+
+        @ar.definition
+        def Height(height: int):
+            return height
+
+        h = Height()
+
+        with py.test.raises(TypeError) as err:
+            h(12)
+
+        assert "must be passed as keyword arguments" in str(err.value)
+
+    def test_simple_param(self):
+        """Ensure that we can define a parameter that takes a simple parameter."""
+
+        @ar.definition
+        def Height(height: int):
+            return height - 1
+
+        h = Height()
+        assert h(height=100) == 99
+
+    def test_attributes(self):
+        """Ensure that we can define a definition that takes a number of attributes."""
+
+        @ar.definition()
+        def Param(*, offset=0):
+            return 2 - offset
+
+        p = Param()
+        assert p() == 2
+
+        q = Param(offset=2)
+        assert q() == 0
+
+    def test_produces_any(self):
+        """Ensure that a definition without a return annotation reports its return type
+        as :code:`Any`."""
+
+        @ar.definition()
+        def Param():
+            pass
+
+        assert Param.produces() == Any
+        assert Param().produces() == Any
+
+    def test_produces(self):
+        """Ensure that a definition reports what type it returns as declared by its
+        return annotation."""
+
+        @ar.definition()
+        def Param() -> int:
+            return 1
+
+        assert Param.produces() == int
+        assert Param().produces() == int
 
 
 class TestDefinitionInputs:
     """Tests relating to definition inputs."""
 
-    def test_inputs_classmethod_constant_defn(self):
+    def test_constant_defn(self):
         """Defns that don't define any inputs should return an empty dict."""
 
         assert Const.inputs() == {}
         assert Const().inputs() == {}
 
-    def test_inputs_classmethod_simple_defn(self):
+    def test_simple_defn(self):
         """Ensure that all explicitly defined definitions are reported."""
 
         expected = {
@@ -202,7 +152,7 @@ class TestDefinitionInputs:
         assert Base.inputs() == expected
         assert Base().inputs() == expected
 
-    def test_inputs_classmethod_simple_derived(self):
+    def test_simple_derived(self):
         """Any inputs from base definitions should also be exposed by default, but
         marked as being inherited."""
 
@@ -217,7 +167,7 @@ class TestDefinitionInputs:
         assert Tunnel.inputs() == expected
         assert Tunnel().inputs() == expected
 
-    def test_inputs_classmethod_simple_derived_inhertited_false(self):
+    def test_simple_derived_inhertited_false(self):
         """Ensure that we can ask only for the inputs that have been directly declared
         on the definition."""
 
@@ -226,7 +176,7 @@ class TestDefinitionInputs:
         assert Tunnel.inputs(inherited=False) == expected
         assert Tunnel().inputs(inherited=False) == expected
 
-    def test_inputs_classmethod_shadowed_inputs(self):
+    def test_shadowed_inputs(self):
         """Ensure that any inputs that are both explicitly declared and carried on a
         base definition are marked as not being inherited."""
 
@@ -241,7 +191,7 @@ class TestDefinitionInputs:
         assert Cuboid.inputs() == expected
         assert Cuboid().inputs() == expected
 
-    def test_inputs_classmethod_shadowed_inputs_many_sources(self):
+    def test_shadowed_inputs_many_sources(self):
         """Ensure that any inputs inherited from multiple sources are captured as
         such."""
 
@@ -297,198 +247,237 @@ class TestDefinitionInputs:
         assert "'Base'" in str(err.value)
 
 
-def test_derived_definition_attributes_inherited():
-    """Ensure that the attributes method with the inherited flag exposes all available
-    attributes on the definition."""
+class TestDerivedDefinitions:
+    """Tests related to deriving definitions."""
 
-    @ar.definition
-    def Base(width: int, height: int, *, a=1, b=2):
-        return 3
+    def test_derivation(self):
+        """Ensure that we can derive a definition that's based on other definitions."""
 
-    assert Base().attributes(inherited=True) == {"a": 1, "b": 2}
+        @ar.definition()
+        def Adder(width: int, height: int):
+            return height + width
 
-    @ar.definition()
-    def Derived(base: Base, *, b=3, d=4):
-        return 5
+        @ar.definition()
+        def Subber(a: Adder):
+            return a - 2
 
-    assert Derived().attributes(inherited=True) == {"a": 1, "b": 3, "d": 4}
+        s = Subber()
+        assert s(width=1, height=1) == 0
+        assert s(width=1, height=2) == 1
 
+    def test_attributes(self):
+        """Ensure that the attributes method only exposes the attributes that are
+        directly defined on the definition by default."""
 
-def test_derived_definition_attributes():
-    """Ensure that the attributes method only exposes the attributes that are directly
-    defined on the definition by default."""
+        @ar.definition
+        def Base(width: int, height: int, *, a=1, b=2):
+            return 3
 
-    @ar.definition
-    def Base(width: int, height: int, *, a=1, b=2):
-        return 3
+        assert Base().attributes() == {"a": 1, "b": 2}
 
-    assert Base().attributes() == {"a": 1, "b": 2}
+        @ar.definition
+        def Derived(base: Base, *, b=3, d=4):
+            return 5
 
-    @ar.definition
-    def Derived(base: Base, *, b=3, d=4):
-        return 5
+        assert Derived().attributes() == {"b": 3, "d": 4}
 
-    assert Derived().attributes() == {"b": 3, "d": 4}
+    def test_inherited_attributes(self):
+        """Ensure that the attributes method with the inherited flag exposes all
+        available attributes on the definition."""
 
+        @ar.definition
+        def Base(width: int, height: int, *, a=1, b=2):
+            return 3
 
-def test_derived_definiton_attribs_inherited():
-    """Ensure that the attribs method with the inherited flag exposes all available
-    attribute definitions."""
+        assert Base().attributes(inherited=True) == {"a": 1, "b": 2}
 
-    @ar.definition
-    def Base(width: int, height: int, *, a=1, b=2):
-        return 3
+        @ar.definition()
+        def Derived(base: Base, *, b=3, d=4):
+            return 5
 
-    attrs = Base.attribs(inherited=True)
-    assert {"a", "b"} == set(attrs.keys())
+        assert Derived().attributes(inherited=True) == {"a": 1, "b": 3, "d": 4}
 
-    for name, attr in attrs.items():
-        assert name == attr.name
+    def test_attribs(self):
+        """Ensure that the attribs method with the inherited flag exposes all available
+        attribute definitions."""
 
-    @ar.definition()
-    def Derived(base: Base, *, b=3, d=4):
-        return 5
+        @ar.definition
+        def Base(width: int, height: int, *, a=1, b=2):
+            return 3
 
-    attrs = Derived.attribs(inherited=True)
-    assert {"a", "b", "d"} == set(attrs.keys())
+        attrs = Base.attribs()
+        assert {"a", "b"} == set(attrs.keys())
 
-    for name, attr in attrs.items():
-        assert name == attr.name
+        for name, attr in attrs.items():
+            assert name == attr.name
 
+        @ar.definition()
+        def Derived(base: Base, *, b=3, d=4):
+            return 5
 
-def test_derived_definiton_attribs():
-    """Ensure that the attribs method with the inherited flag exposes all available
-    attribute definitions."""
+        attrs = Derived.attribs()
+        assert {"b", "d"} == set(attrs.keys())
 
-    @ar.definition
-    def Base(width: int, height: int, *, a=1, b=2):
-        return 3
+        for name, attr in attrs.items():
+            assert name == attr.name
 
-    attrs = Base.attribs()
-    assert {"a", "b"} == set(attrs.keys())
+    def test_inherited_attribs(self):
+        """Ensure that the attribs method with the inherited flag exposes all available
+        attribute definitions."""
 
-    for name, attr in attrs.items():
-        assert name == attr.name
+        @ar.definition
+        def Base(width: int, height: int, *, a=1, b=2):
+            return 3
 
-    @ar.definition()
-    def Derived(base: Base, *, b=3, d=4):
-        return 5
+        attrs = Base.attribs(inherited=True)
+        assert {"a", "b"} == set(attrs.keys())
 
-    attrs = Derived.attribs()
-    assert {"b", "d"} == set(attrs.keys())
+        for name, attr in attrs.items():
+            assert name == attr.name
 
-    for name, attr in attrs.items():
-        assert name == attr.name
+        @ar.definition()
+        def Derived(base: Base, *, b=3, d=4):
+            return 5
 
+        attrs = Derived.attribs(inherited=True)
+        assert {"a", "b", "d"} == set(attrs.keys())
 
-def test_derived_definition_eval_kwargs():
-    """Ensure that a definition can be evaluted with inputs provided as keyword
-    arguments"""
+        for name, attr in attrs.items():
+            assert name == attr.name
 
-    @ar.definition()
-    def Base(width: int, height: int):
-        return width + height
+    def test_eval_kwargs(self):
+        """Ensure that a definition can be evaluted with inputs provided as keyword
+        arguments"""
 
-    assert Base()(width=4, height=4) == 8
+        @ar.definition()
+        def Base(width: int, height: int):
+            return width + height
 
-    @ar.definition()
-    def Derived(height: int, base: Base):
-        return height - base
+        assert Base()(width=4, height=4) == 8
 
-    assert Derived()(height=4, base=4) == 0
+        @ar.definition()
+        def Derived(height: int, base: Base):
+            return height - base
 
+        assert Derived()(height=4, base=4) == 0
 
-@py.test.mark.parametrize(
-    "op,fn",
-    [
-        (ar.Defn.OP_ADD, lambda a, b: a + b),
-        (ar.Defn.OP_AND, lambda a, b: a & b),
-        (ar.Defn.OP_DIV, lambda a, b: a / b),
-        (ar.Defn.OP_FLOORDIV, lambda a, b: a // b),
-        (ar.Defn.OP_LSHIFT, lambda a, b: a << b),
-        (ar.Defn.OP_MATMUL, lambda a, b: a @ b),
-        (ar.Defn.OP_MOD, lambda a, b: a % b),
-        (ar.Defn.OP_MUL, lambda a, b: a * b),
-        (ar.Defn.OP_OR, lambda a, b: a | b),
-        (ar.Defn.OP_POW, lambda a, b: a ** b),
-        (ar.Defn.OP_RSHIFT, lambda a, b: a >> b),
-        (ar.Defn.OP_SUB, lambda a, b: a - b),
-        (ar.Defn.OP_XOR, lambda a, b: a ^ b),
-    ],
-)
-def test_definition_binary_operation_not_supported_other_objects(op, fn):
-    """Ensure that we throw a sensible error if a user tries to perform an operation
-    with an object that is not supported."""
+    def test_exposes_attributes(self):
+        """Ensure that any attributes on base definitions are exposed on the derived
+        definition."""
 
-    @ar.definition()
-    def Defn():
-        pass
+        @ar.definition()
+        def Base(width: int, height: int, *, offset=0):
+            return offset
 
-    defn = Defn()
-    op_name = op.capitalize().replace("_", " ")
-    message = "{} is not supported between {} and {}"
+        @ar.definition()
+        def Derived(b: Base, *, start=1):
+            return start - b
 
-    with py.test.raises(TypeError) as err:
-        fn(defn, 1)
+        d = Derived()
+        d(width=1, height=1) == 1
 
-    assert message.format(op_name, "Defn[Any]", "int") == str(err.value)
+        d = Derived(start=5, offset=-1)
+        d(width=1, height=1) == 6
 
-    with py.test.raises(TypeError) as err:
-        fn(1, defn)
+    @py.test.mark.parametrize("defn,expected", [(Base, {}), (Tunnel, {"base": Base})])
+    def test_bases(self, defn, expected):
+        """Ensure that any bases a definition is derived from is exposed."""
 
-    assert message.format(op_name, "int", "Defn[Any]") == str(err.value)
+        assert defn.bases() == expected
+        assert defn().bases() == expected
 
 
-def test_definition_operator_missing_attributes():
-    """Ensure that an operator defines an :code:`a` and :code:`b` attribute"""
+class TestDefinitionOperations:
+    """Tests related to definition operations."""
 
-    with py.test.raises(TypeError) as err:
+    @py.test.mark.parametrize(
+        "op,fn",
+        [
+            (ar.Defn.OP_ADD, lambda a, b: a + b),
+            (ar.Defn.OP_AND, lambda a, b: a & b),
+            (ar.Defn.OP_DIV, lambda a, b: a / b),
+            (ar.Defn.OP_FLOORDIV, lambda a, b: a // b),
+            (ar.Defn.OP_LSHIFT, lambda a, b: a << b),
+            (ar.Defn.OP_MATMUL, lambda a, b: a @ b),
+            (ar.Defn.OP_MOD, lambda a, b: a % b),
+            (ar.Defn.OP_MUL, lambda a, b: a * b),
+            (ar.Defn.OP_OR, lambda a, b: a | b),
+            (ar.Defn.OP_POW, lambda a, b: a ** b),
+            (ar.Defn.OP_RSHIFT, lambda a, b: a >> b),
+            (ar.Defn.OP_SUB, lambda a, b: a - b),
+            (ar.Defn.OP_XOR, lambda a, b: a ^ b),
+        ],
+    )
+    def test_binary_operation_not_supported_other_objects(self, op, fn):
+        """Ensure that we throw a sensible error if a user tries to perform an operation
+        with an object that is not supported."""
 
-        @ar.definition(operation="op")
-        def Op(width: int, height: int):
+        @ar.definition()
+        def Defn():
             pass
 
-    assert "must define 2 attributes" in str(err.value)
-    assert "'a'" in str(err.value)
-    assert "'b'" in str(err.value)
+        defn = Defn()
+        op_name = op.capitalize().replace("_", " ")
+        message = "{} is not supported between {} and {}"
 
+        with py.test.raises(TypeError) as err:
+            fn(defn, 1)
 
-def test_definition_operator_missing_annotation():
-    """Ensure that an operator defines a type annotation for each input"""
+        assert message.format(op_name, "Defn[Any]", "int") == str(err.value)
 
-    with py.test.raises(TypeError) as err:
+        with py.test.raises(TypeError) as err:
+            fn(1, defn)
 
-        @ar.definition(operation="op")
-        def OpA(width: int, height: int, *, a=1, b: int = 2):
-            pass
+        assert message.format(op_name, "int", "Defn[Any]") == str(err.value)
 
-    assert "missing a valid type annotation" in str(err.value)
-    assert "'a'" in str(err.value)
+    def test_operator_missing_attributes(self):
+        """Ensure that an operator defines an :code:`a` and :code:`b` attribute"""
 
-    with py.test.raises(TypeError) as err:
+        with py.test.raises(TypeError) as err:
 
-        @ar.definition(operation="op")
-        def OpB(width: int, height: int, *, a: int = 1, b=2):
-            pass
+            @ar.definition(operation="op")
+            def Op(width: int, height: int):
+                pass
 
-    assert "missing a valid type annotation" in str(err.value)
-    assert "'b'" in str(err.value)
+        assert "must define 2 attributes" in str(err.value)
+        assert "'a'" in str(err.value)
+        assert "'b'" in str(err.value)
 
+    def test_operator_missing_annotation(self):
+        """Ensure that an operator defines a type annotation for each input"""
 
-def test_definition_operator_existing_definition():
-    """Ensure that if an existing operator has already been defined an error is
-    thrown."""
+        with py.test.raises(TypeError) as err:
 
-    operator_pool = {}
+            @ar.definition(operation="op")
+            def OpA(width: int, height: int, *, a=1, b: int = 2):
+                pass
 
-    @ar.definition(operation="op", operator_pool=operator_pool)
-    def Op(width: int, height: int, *, a: int = 0, b: int = 0):
-        pass
+        assert "missing a valid type annotation" in str(err.value)
+        assert "'a'" in str(err.value)
 
-    with py.test.raises(TypeError) as err:
+        with py.test.raises(TypeError) as err:
+
+            @ar.definition(operation="op")
+            def OpB(width: int, height: int, *, a: int = 1, b=2):
+                pass
+
+        assert "missing a valid type annotation" in str(err.value)
+        assert "'b'" in str(err.value)
+
+    def test_operator_existing_definition(self):
+        """Ensure that if an existing operator has already been defined an error is
+        thrown."""
+
+        operator_pool = {}
 
         @ar.definition(operation="op", operator_pool=operator_pool)
-        def OpDuplicate(width: int, height: int, *, a: int = 0, b: int = 0):
+        def Op(width: int, height: int, *, a: int = 0, b: int = 0):
             pass
 
-    assert "has already been defined" in str(err.value)
+        with py.test.raises(TypeError) as err:
+
+            @ar.definition(operation="op", operator_pool=operator_pool)
+            def OpDuplicate(width: int, height: int, *, a: int = 0, b: int = 0):
+                pass
+
+        assert "has already been defined" in str(err.value)


### PR DESCRIPTION
As outlined in #252 having type annotations be strings at runtime by default in 3.9 would break the way we currently construct definitions. This PR should now ensure that we are future compatible with 3.9 by opting into this behaviour through a `__future__`
import. This does mean however we're dropping support for Python 3.6

Main highlights include
- Using `typing.get_type_hints()` to get the real type annotations at runtime
- Refactored the overall construction of definitions to be more explicit what is an attribute, base, input etc
- Implement custom generic type annotations the "right" way by basing `Defn` on `Generic[T]`. Hopefully this means we play nicer with the overall type hinting space 

Closes #252